### PR TITLE
Fix depends that aren't test depends only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ project(ros_msg_parser)
 
 find_package(Boost REQUIRED COMPONENTS regex)
 
-find_package(catkin REQUIRED COMPONENTS 
+find_package(catkin REQUIRED COMPONENTS
+    geometry_msgs
+    sensor_msgs
     roscpp
     roscpp_serialization
     rosbag_storage
@@ -13,13 +15,14 @@ find_package(catkin REQUIRED COMPONENTS
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 ")
 
 catkin_package(
-   INCLUDE_DIRS include
-   LIBRARIES ros_msg_parser
-   CATKIN_DEPENDS 
-   roscpp 
-   roscpp_serialization
-   rosbag_storage
-   DEPENDS 
+  INCLUDE_DIRS include
+  LIBRARIES ros_msg_parser
+  CATKIN_DEPENDS
+    geometry_msgs
+    sensor_msgs
+    roscpp
+    roscpp_serialization
+    rosbag_storage
 )
 
 ###########
@@ -47,17 +50,6 @@ include_directories(
 
 target_link_libraries(ros_msg_parser ${catkin_LIBRARIES})
 
-
-add_executable(ros_msg_parsing_test
-#    tests/parser_test.cpp
-    tests/deserializer_test.cpp
-    )
-
-target_link_libraries(ros_msg_parsing_test
-    ros_msg_parser
-    gtest
-    ${catkin_LIBRARIES}
-    )
 
 find_package(benchmark CONFIG)
 if (benchmark_FOUND)
@@ -92,16 +84,15 @@ target_link_libraries(selective_deserialization ros_msg_parser ${catkin_LIBRARIE
 ## Testing ##
 #############
 if(CATKIN_ENABLE_TESTING)
+  add_executable(ros_msg_parsing_test
+    tests/deserializer_test.cpp
+  )
 
-#    catkin_add_gtest(ros_parsing_test
-##        tests/parser_test.cpp
-#        tests/deserializer_test.cpp
-#        )
-
-#    target_link_libraries(ros_parsing_test
-#        ros_msg_parser
-#        ${catkin_LIBRARIES}
-#        )
+  target_link_libraries(ros_msg_parsing_test
+    ros_msg_parser
+    gtest
+    ${catkin_LIBRARIES}
+  )
 endif()
 
 #############

--- a/package.xml
+++ b/package.xml
@@ -14,18 +14,19 @@
   <author email="davide.faconti@gmail.com">Davide Faconti</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
-    <build_depend>roscpp</build_depend>
-    <build_depend>roscpp_serialization</build_depend>
-    <build_depend>rosbag_storage</build_depend>
 
-    <run_depend>roscpp</run_depend>
-    <run_depend>roscpp_serialization</run_depend>
-    <run_depend>rosbag_storage</run_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>roscpp_serialization</build_depend>
+  <build_depend>rosbag_storage</build_depend>
 
-    <test_depend>gtest</test_depend>
-    <test_depend>geometry_msgs</test_depend>
-    <test_depend>sensor_msgs</test_depend>
-    <test_depend>tf2</test_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>roscpp_serialization</run_depend>
+  <run_depend>rosbag_storage</run_depend>
 
+  <test_depend>gtest</test_depend>
+  <test_depend>tf2</test_depend>
 </package>


### PR DESCRIPTION
This is a bit hacky, but it's the easiest way I could came with to get the dependencies for the **examples** to get installed in an isolated install. Same for the benchmark. Those targets are always built, not only in test mode. So moving the test inside the `CATKIN_ENABLE_TESTING` wasn't enough.