### PR TITLE
Allow direct access to variant data

### DIFF
--- a/include/ros_msg_parser/utils/variant.hpp
+++ b/include/ros_msg_parser/utils/variant.hpp
@@ -118,6 +118,9 @@ public:
 
   void assign(const char* buffer, size_t length);
 
+  // Direct access to raw data. Undefined behavior if this variant holds a STRING
+  const uint8_t* getRawStorage() const;
+
 private:
 
   union {
@@ -164,6 +167,10 @@ inline Variant::~Variant()
 
 inline BuiltinType Variant::getTypeID() const {
   return _type;
+}
+
+inline const uint8_t* Variant::getRawStorage() const { 
+  return _storage.raw_data.data(); 
 }
 
 template<typename T> inline T Variant::extract( ) const


### PR DESCRIPTION
Adds a `Variant::getRawStorage` to access the raw internals directly. It's unsafe, and results in undefined behavior if the variant holds a string, but it's handy for generic code that wants to pass the raw data directly without extra copies. I'm using this in https://github.com/samkhal/fast_rosbag_pandas to copy the bytes directly into a numpy ndarray.