### PR TITLE
Allow rapidjson writer to handle nan and inf values

### DIFF
--- a/src/ros_parser.cpp
+++ b/src/ros_parser.cpp
@@ -586,11 +586,21 @@ bool Parser::deserializeIntoJson(Span<const uint8_t> buffer, std::string* json_t
   json_buffer.Reserve(2048);
 
   if( pretty_printer ){
-    rapidjson::PrettyWriter<rapidjson::StringBuffer> json_writer(json_buffer);
+    rapidjson::PrettyWriter<rapidjson::StringBuffer,
+                            rapidjson::UTF8<>,
+                            rapidjson::UTF8<>,
+                            rapidjson::CrtAllocator,
+                            rapidjson::kWriteDefaultFlags |
+                              rapidjson::kWriteNanAndInfFlag> json_writer(json_buffer);
     json_document.Accept(json_writer);
   }
   else{
-    rapidjson::Writer<rapidjson::StringBuffer> json_writer(json_buffer);
+    rapidjson::Writer<rapidjson::StringBuffer,
+                      rapidjson::UTF8<>,
+                      rapidjson::UTF8<>,
+                      rapidjson::CrtAllocator,
+                      rapidjson::kWriteDefaultFlags |
+                        rapidjson::kWriteNanAndInfFlag> json_writer(json_buffer);
     json_document.Accept(json_writer);
   }
   *json_txt = json_buffer.GetString();


### PR DESCRIPTION
Fixes https://github.com/facontidavide/ros_msg_parser/issues/8

NaN and Inf are not allowed values in JSON but are allowed values in ROS messages. 

This allows the writer to go out of the JSON spec and write the values regardless, since presumably having invalid JSON is better than the writer arbitrarily stopping halfway through.