### PR TITLE
Fix linking of target ros_parser_benchmark to the benchmark library installed at a non-default location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if (benchmark_FOUND)
     target_link_libraries(ros_parser_benchmark
         ros_msg_parser
         ${catkin_LIBRARIES}
-        benchmark
+        benchmark::benchmark
         pthread
         )
 endif(benchmark_FOUND)


### PR DESCRIPTION
There is no CMake target named `benchmark`. If I have the library installed at a non-default location, linking to `benchmark` fails with:

```
[ 95%] Linking CXX executable [...]/ros_parser_benchmark                                                                  
/usr/bin/ld: cannot find -lbenchmark                                                                                                                                             
```

In my case the package has been found at
```sh
$ grep benchmark build/ros_msg_parser/CMakeCache.txt 
//The directory containing a CMake configuration file for benchmark.
benchmark_DIR:PATH=/opt/ros/intermodalics/lib/cmake/benchmark
$ ll /opt/ros/intermodalics/lib/libbenchmark.so*
lrwxrwxrwx 1 root root     17 Sep 24 10:50 /opt/ros/intermodalics/lib/libbenchmark.so -> libbenchmark.so.1
lrwxrwxrwx 1 root root     21 Sep 24 10:50 /opt/ros/intermodalics/lib/libbenchmark.so.1 -> libbenchmark.so.1.4.0
-rw-r--r-- 1 root root 350296 Sep 24 10:50 /opt/ros/intermodalics/lib/libbenchmark.so.1.4.0
```
for our custom-built ROS distribution (which includes some non-ROS dependencies).

See also the usage example at https://github.com/google/benchmark#usage-with-cmake.

Thanks for making this useful package and the amazing PlotJuggler!