### PR TITLE
Fix ReadFromBuffer() for empty strings in Debug mode

### DIFF
--- a/include/ros_msg_parser/helper_functions.hpp
+++ b/include/ros_msg_parser/helper_functions.hpp
@@ -97,6 +97,11 @@ template <> inline void ReadFromBuffer( const Span<const uint8_t>& buffer, size_
     throw std::runtime_error("Buffer overrun in RosMsgParser::ReadFromBuffer");
   }
 
+  if (string_size == 0) {
+    destination = std::string();
+    return;
+  }
+
   const char* buffer_ptr = reinterpret_cast<const char*>( &buffer[offset] );
   offset += string_size;
 


### PR DESCRIPTION
If the string to be read is empty (`string_size == 0`) and the package that includes this header is compiled in debug mode, then [this assertion in `Span::operator[]`](https://github.com/Intermodalics/ros_msg_parser/blob/0cb17e58767abab30d350d1c8fad383dba2d50e9/include/ros_msg_parser/utils/span.hpp#L1061) can fail because `buffer[offset]` would access the span past its boundaries.

I assume that the implementations of `std::string::assign(buffer_ptr, string_size)` ignore the `buffer_ptr` if `string_size == 0`, but better to handle this case separately...