### PR TITLE
Fix recursive include warning

### DIFF
--- a/include/ros_msg_parser/utils/shape_shifter.hpp
+++ b/include/ros_msg_parser/utils/shape_shifter.hpp
@@ -38,7 +38,6 @@
 #include "ros/assert.h"
 #include <vector>
 #include <ros/message_traits.h>
-#include "ros_msg_parser/ros_parser.hpp"
 
 namespace RosMsgParser
 {


### PR DESCRIPTION
Addresses #13 by removing the include directive from `shape_shifter.hpp`