### PR TITLE
Fix ROSMessage::updateMissingPkgNames() for ambiguous message names

### DIFF
--- a/src/ros_message.cpp
+++ b/src/ros_message.cpp
@@ -33,6 +33,8 @@
 * *******************************************************************/
 
 
+#include <algorithm>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/utility/string_ref.hpp>
 #include <boost/utility/string_ref.hpp>
@@ -76,23 +78,30 @@ ROSMessage::ROSMessage(const std::string &msg_def)
 
 void ROSMessage::updateMissingPkgNames(const std::vector<const ROSType*> &all_types)
 {
+  // From http://wiki.ros.org/msg#Fields
+  //   When embedding other Message descriptions, the type name may be relative
+  //   (e.g. "Point32") if it is in the same package; otherwise it must be the
+  //   full Message type (e.g. "std_msgs/String"). The only exception to this
+  //   rule is Header.
   for (ROSField& field: _fields)
   {
-    // if package name is missing, try to find msgName in the list of known_type
-    if( field.type().pkgName().size() == 0 )
+    // if package name is missing, try to find pkgName/msgName in the list of all_types
+    if( field.type().pkgName().size() != 0 ) continue;
+    const auto found = std::find_if(
+        all_types.begin(), all_types.end(),
+        [&](const ROSType* known_type) {
+          return ( (this->type().pkgName().compare( known_type->pkgName() ) == 0) &&
+                   (field.type().msgName().compare( known_type->msgName() ) == 0) );
+        });
+    if (found != all_types.end())
     {
-      for (const ROSType* known_type: all_types)
-      {
-        if( field.type().msgName().compare( known_type->msgName() ) == 0  )
-        {
-          field._type.setPkgName( known_type->pkgName() );
-          break;
-        }
-      }
+      field._type.setPkgName( (*found)->pkgName() );
+    }
+    else if ( field.type().msgName() == "Header" )
+    {
+      field._type.setPkgName( "std_msgs" );
     }
   }
 }
 
 } // end namespace
-
-

--- a/src/ros_parser.cpp
+++ b/src/ros_parser.cpp
@@ -106,7 +106,7 @@ void Parser::registerMessage(const std::string& definition)
         next_msg = getMessageByType(field.type());
         if (next_msg == nullptr)
         {
-          throw std::runtime_error("This type was not registered ");
+          throw std::runtime_error("Type " + field.type().baseName() + " was not registered");
         }
         msg_node->addChild(next_msg);
         MessageTreeNode* new_msg_node = &(msg_node->children().back());


### PR DESCRIPTION
Fix `ROSMessage::updateMissingPkgNames()` for the case that types with the same message name but different package names are registered.

We used `ros_msg_parser` in a case where a message was using two different definitions of `Header`, a custom one with additional fields, but also `std_msgs/Header` indirectly via a nested [`geometry_msgs/Vector3Stamped`](https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Vector3Stamped.html) defined as
```
# This represents a Vector3 with reference coordinate frame and timestamp
Header header
Vector3 vector
```
so without an explicit package name for `Header` and `Vector3`. The previous implementation of `ROSMessage::updateMissingPkgNames()` then completed this type with the name of the custom package, whose `Header` message was registered first, and hence parsing failed.

According to the rules defined in http://wiki.ros.org/msg#Fields unqualified types must be resolved in the local package only, with `Header` as the only exception. I assume that `Header` is only resolved to `std_msgs/Header` if no message named `Header` is defined in the same package.

