### PR TITLE
Adding JSON to ROS Message Serialization Functionality

### DIFF
--- a/include/ros_msg_parser/ros_parser.hpp
+++ b/include/ros_msg_parser/ros_parser.hpp
@@ -1,25 +1,25 @@
 /***** MIT License ****
-*
-*   Copyright (c) 2016-2022 Davide Faconti
-*
-*   Permission is hereby granted, free of charge, to any person obtaining a copy
-*   of this software and associated documentation files (the "Software"), to deal
-*   in the Software without restriction, including without limitation the rights
-*   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-*   copies of the Software, and to permit persons to whom the Software is
-*   furnished to do so, subject to the following conditions:
-*
-*   The above copyright notice and this permission notice shall be included in all
-*   copies or substantial portions of the Software.
-*
-*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-*   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-*   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-*   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-*   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-*   SOFTWARE.
-*/
+ *
+ *   Copyright (c) 2016-2022 Davide Faconti
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
 #pragma once
 
 #include <unordered_set>
@@ -29,287 +29,302 @@
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
 
-namespace RosMsgParser{
+namespace RosMsgParser
+{
 
-struct FlatMessage {
+  struct FlatMessage
+  {
 
-  /// Tree that the FieldTreeLeaf(s) refer to.
-  std::shared_ptr<ROSMessageInfo> msg_info;
+    /// Tree that the FieldTreeLeaf(s) refer to.
+    std::shared_ptr<ROSMessageInfo> msg_info;
 
-  /// List of all those parsed fields that can be represented by a builtin value different from "string".
-  /// This list will be filled by the funtion buildRosFlatType.
-  std::vector< std::pair<FieldTreeLeaf, Variant> > value;
+    /// List of all those parsed fields that can be represented by a builtin value different from "string".
+    /// This list will be filled by the funtion buildRosFlatType.
+    std::vector<std::pair<FieldTreeLeaf, Variant>> value;
 
-  /// List of all those parsed fields that can be represented by a builtin value equal to "string".
-  /// This list will be filled by the funtion buildRosFlatType.
-  std::vector< std::pair<FieldTreeLeaf, std::string> > name;
+    /// List of all those parsed fields that can be represented by a builtin value equal to "string".
+    /// This list will be filled by the funtion buildRosFlatType.
+    std::vector<std::pair<FieldTreeLeaf, std::string>> name;
 
-  /// Store "blobs", i.e all those fields which are vectors of BYTES (AKA uint8_t),
-  /// where the vector size is greater than the argument [max_array_size]
-  /// passed  to the function deserializeIntoFlatContainer
-  std::vector< std::pair<FieldTreeLeaf, Span<const uint8_t>>> blob;
+    /// Store "blobs", i.e all those fields which are vectors of BYTES (AKA uint8_t),
+    /// where the vector size is greater than the argument [max_array_size]
+    /// passed  to the function deserializeIntoFlatContainer
+    std::vector<std::pair<FieldTreeLeaf, Span<const uint8_t>>> blob;
 
-  std::vector<std::vector<uint8_t>> blob_storage;
-};
-
-
-class Parser{
-
-public:
-  /**
-   *
-   * @param topic_name   name of the topic to be used as node of the StringTree
-   * @param msg_type     message type of the topic.
-   * @param msg_definition text obtained by either:
-   *                       - topic_tools::ShapeShifter::getMessageDefinition()
-   *                       - rosbag::MessageInstance::getMessageDefinition()
-   *                       - ros::message_traits::Definition< __your_type__ >::value()
-   * */
-  Parser(const std::string& topic_name, const ROSType& msg_type, const std::string& definition);
-
-  enum MaxArrayPolicy: bool {
-    DISCARD_LARGE_ARRAYS = true,
-    KEEP_LARGE_ARRAYS = false
+    std::vector<std::vector<uint8_t>> blob_storage;
   };
 
-  /// Default values are DISCARD_LARGE_ARRAYS and 100.
-  /// The maximum permissible value of max_array_size is 10.000 (but don't)
-  void setMaxArrayPolicy( MaxArrayPolicy discard_entire_array, size_t max_array_size )
+  class Parser
   {
+
+  public:
+    /**
+     *
+     * @param topic_name   name of the topic to be used as node of the StringTree
+     * @param msg_type     message type of the topic.
+     * @param msg_definition text obtained by either:
+     *                       - topic_tools::ShapeShifter::getMessageDefinition()
+     *                       - rosbag::MessageInstance::getMessageDefinition()
+     *                       - ros::message_traits::Definition< __your_type__ >::value()
+     * */
+    Parser(const std::string &topic_name, const ROSType &msg_type, const std::string &definition);
+
+    enum MaxArrayPolicy : bool
+    {
+      DISCARD_LARGE_ARRAYS = true,
+      KEEP_LARGE_ARRAYS = false
+    };
+
+    /// Default values are DISCARD_LARGE_ARRAYS and 100.
+    /// The maximum permissible value of max_array_size is 10.000 (but don't)
+    void setMaxArrayPolicy(MaxArrayPolicy discard_entire_array, size_t max_array_size)
+    {
       _discard_large_array = discard_entire_array;
       _max_array_size = max_array_size;
-      if( _max_array_size > 10000 )
+      if (_max_array_size > 10000)
       {
         throw std::runtime_error("max_array_size limited to 10000 at most");
       }
-  }
+    }
 
-  MaxArrayPolicy maxArrayPolicy() const
+    MaxArrayPolicy maxArrayPolicy() const
+    {
+      return _discard_large_array;
+    }
+
+    size_t maxArraySizy() const
+    {
+      return _max_array_size;
+    }
+
+    enum BlobPolicy
+    {
+      STORE_BLOB_AS_COPY,
+      STORE_BLOB_AS_REFERENCE
+    };
+
+    // If set to STORE_BLOB_AS_COPY, a copy of the original vector will be stored in the FlatMessage.
+    // This may have a large impact on performance.
+    // if STORE_BLOB_AS_REFERENCE is used instead, it is dramatically faster, but you must be careful with
+    // dangling pointers.
+    void setBlobPolicy(BlobPolicy policy)
+    {
+      _blob_policy = policy;
+    }
+
+    BlobPolicy blobPolicy() const
+    {
+      return _blob_policy;
+    }
+
+    /**
+     * @brief getMessageInfo provides some metadata amout a registered ROSMessage.
+     *
+     * @param msg_identifier String ID to identify the registered message (use registerMessageDefinition first).
+     * @return               Pointer to the instance or nullptr if not registered.
+     */
+    const std::shared_ptr<ROSMessageInfo> &getMessageInfo() const;
+
+    const ROSMessage *getMessageByType(const ROSType &type) const;
+
+    /**
+     * @brief deserializeIntoFlatContainer takes a raw buffer of memory and extract information from it.
+     *  This data is stored in two key/value vectors, FlatMessage::value and FlatMessage::name.
+     * It must be noted that the key type is FieldTreeLeaf. this type is not particularly user-friendly,
+     * but allows a much faster post-processing.
+     *
+     * IMPORTANT: this approach is not meant to be used with use arrays such as maps, point clouds and images.
+     * It would require a ridicoulous amount of memory and, franckly, make little sense.
+     * For this reason the argument max_array_size is used.
+     *
+     * This funtion is almost always followed by applyNameTransform, which provide a more human-readable
+     * key-value representation.
+     *
+     * @param buffer           raw memory to be parsed.
+     * @param flat_container_output  output to store the result. It is recommended to reuse the same object multiple times to
+     *                               avoid memory allocations and speed up the parsing.
+     *
+     * return true if the entire message was parsed or false if parts of the message were
+     * skipped because an array has (size > max_array_size)
+     */
+    bool deserializeIntoFlatMsg(Span<const uint8_t> buffer,
+                                FlatMessage *flat_container_output) const;
+
+    /**
+     * @param combineSecNsec           whether the json should have timestamp as {s.nsec},
+     *                                 or { secs: s , nsecs: ns} to match the format of a ROS message
+     *                               
+     *
+     */
+    bool deserializeIntoJson(Span<const uint8_t> buffer,
+                             std::string *json_txt,
+                             bool pretty_printer = false,
+                             bool combineSecNsec = true) const;
+
+    bool serializeFromJson(std::vector<uint8_t> &bufferOut,
+                           std::string *json_txt) const;
+
+    typedef std::function<void(const ROSType &, Span<uint8_t> &)> VisitingCallback;
+
+    /**
+     * @brief applyVisitorToBuffer is used to pass a callback that is invoked every time
+     *        a chunk of memory storing an instance of ROSType = monitored_type
+     *        is reached.
+     *        Note that the VisitingCallback can modify the original message, but can NOT
+     *        change its size. This means that strings and vectors can not be change their length.
+     *
+     * @param msg_identifier    String ID to identify the registered message (use registerMessageDefinition first).
+     * @param monitored_type    ROSType that triggers the invokation to the callback
+     * @param buffer            Original buffer, passed as mutable since it might be modified.
+     * @param callback          The callback.
+     */
+    void applyVisitorToBuffer(const ROSType &msg_type,
+                              Span<uint8_t> &buffer,
+                              VisitingCallback callback) const;
+
+    template <typename T>
+    T extractField(const Span<uint8_t> &buffer) const;
+
+    /// Change where the warning messages are displayed.
+    void setWarningsStream(std::ostream *output) { _global_warnings = output; }
+
+  private:
+    void registerMessage(const std::string &definition);
+
+    std::shared_ptr<ROSMessageInfo> _message_info;
+
+    std::ostream *_global_warnings;
+
+    std::string _topic_name;
+    ROSType _msg_type;
+
+    std::vector<int> _alias_array_pos;
+    std::vector<std::string> _formatted_string;
+    std::vector<int8_t> _substituted;
+    MaxArrayPolicy _discard_large_array;
+    size_t _max_array_size;
+    BlobPolicy _blob_policy;
+    std::shared_ptr<ROSField> _dummy_root_field;
+  };
+
+  typedef std::vector<std::pair<std::string, double>> RenamedValues;
+
+  void CreateRenamedValues(const FlatMessage &flat_msg, RenamedValues &renamed);
+
+  class ParsersCollection
   {
-    return _discard_large_array;
-  }
 
-  size_t maxArraySizy() const
-  {
-    return _max_array_size;
-  }
+  public:
+    struct DeserializedMsg
+    {
+      FlatMessage flat_msg;
+      RenamedValues renamed_vals;
+    };
 
-  enum BlobPolicy {
-    STORE_BLOB_AS_COPY,
-    STORE_BLOB_AS_REFERENCE};
+    void registerParser(const std::string &topic_name,
+                        const ROSType &msg_type, const std::string &definition);
 
-  // If set to STORE_BLOB_AS_COPY, a copy of the original vector will be stored in the FlatMessage.
-  // This may have a large impact on performance.
-  // if STORE_BLOB_AS_REFERENCE is used instead, it is dramatically faster, but you must be careful with
-  // dangling pointers.
-  void setBlobPolicy( BlobPolicy policy )
-  {
-    _blob_policy = policy;
-  }
+    void registerParser(const std::string &topic_name,
+                        const RosMsgParser::ShapeShifter &msg);
 
-  BlobPolicy blobPolicy() const
-  {
-    return _blob_policy;
-  }
+    void registerParser(const std::string &topic_name,
+                        const rosbag::ConnectionInfo &connection);
 
-  /**
-   * @brief getMessageInfo provides some metadata amout a registered ROSMessage.
-   *
-   * @param msg_identifier String ID to identify the registered message (use registerMessageDefinition first).
-   * @return               Pointer to the instance or nullptr if not registered.
-   */
-  const std::shared_ptr<ROSMessageInfo> &getMessageInfo() const;
+    const Parser *getParser(const std::string &topic_name) const;
 
-  const ROSMessage* getMessageByType(const ROSType& type) const;
+    const DeserializedMsg *deserialize(const std::string &topic_name,
+                                       Span<const uint8_t> buffer);
 
-  /**
-   * @brief deserializeIntoFlatContainer takes a raw buffer of memory and extract information from it.
-   *  This data is stored in two key/value vectors, FlatMessage::value and FlatMessage::name.
-   * It must be noted that the key type is FieldTreeLeaf. this type is not particularly user-friendly,
-   * but allows a much faster post-processing.
-   *
-   * IMPORTANT: this approach is not meant to be used with use arrays such as maps, point clouds and images.
-   * It would require a ridicoulous amount of memory and, franckly, make little sense.
-   * For this reason the argument max_array_size is used.
-   *
-   * This funtion is almost always followed by applyNameTransform, which provide a more human-readable
-   * key-value representation.
-   *
-   * @param buffer           raw memory to be parsed.
-   * @param flat_container_output  output to store the result. It is recommended to reuse the same object multiple times to
-   *                               avoid memory allocations and speed up the parsing.
-   *
-   * return true if the entire message was parsed or false if parts of the message were
-   * skipped because an array has (size > max_array_size)
-   */
-  bool deserializeIntoFlatMsg(Span<const uint8_t> buffer,
-                              FlatMessage* flat_container_output) const;
+    const DeserializedMsg *deserialize(const std::string &topic_name,
+                                       const ShapeShifter &msg);
 
-  bool deserializeIntoJson(Span<const uint8_t> buffer,
-                           std::string* json_txt,
-                           bool pretty_printer = false) const;
+    const DeserializedMsg *deserialize(const std::string &topic_name,
+                                       const rosbag::MessageInstance &msg);
 
-  typedef std::function<void(const ROSType&, Span<uint8_t>&)> VisitingCallback;
+  private:
+    struct CachedPack
+    {
+      Parser parser;
+      DeserializedMsg msg;
+    };
+    std::unordered_map<std::string, CachedPack> _pack;
+    std::vector<uint8_t> _buffer;
+  };
 
-  /**
-   * @brief applyVisitorToBuffer is used to pass a callback that is invoked every time
-   *        a chunk of memory storing an instance of ROSType = monitored_type
-   *        is reached.
-   *        Note that the VisitingCallback can modify the original message, but can NOT
-   *        change its size. This means that strings and vectors can not be change their length.
-   *
-   * @param msg_identifier    String ID to identify the registered message (use registerMessageDefinition first).
-   * @param monitored_type    ROSType that triggers the invokation to the callback
-   * @param buffer            Original buffer, passed as mutable since it might be modified.
-   * @param callback          The callback.
-   */
-  void applyVisitorToBuffer(const ROSType &msg_type,
-                            Span<uint8_t> &buffer,
-                            VisitingCallback callback) const;
+  //---------------------------------------------------
 
   template <typename T>
-  T extractField(const Span<uint8_t> &buffer) const;
-
-
-  /// Change where the warning messages are displayed.
-  void setWarningsStream(std::ostream* output) { _global_warnings = output; }
-
-private:
-  void registerMessage(const std::string& definition);
-
-  std::shared_ptr<ROSMessageInfo> _message_info;
-
-
-  std::ostream* _global_warnings;
-
-  std::string _topic_name;
-  ROSType _msg_type;
-
-  std::vector<int> _alias_array_pos;
-  std::vector<std::string> _formatted_string;
-  std::vector<int8_t> _substituted;
-  MaxArrayPolicy _discard_large_array;
-  size_t _max_array_size;
-  BlobPolicy _blob_policy;
-  std::shared_ptr<ROSField> _dummy_root_field;
-};
-
-typedef std::vector<std::pair<std::string, double> > RenamedValues;
-
-void CreateRenamedValues(const FlatMessage& flat_msg, RenamedValues& renamed);
-
-
-class ParsersCollection{
-
-public:
-  struct DeserializedMsg{
-    FlatMessage flat_msg;
-    RenamedValues renamed_vals;
-  };
-
-  void registerParser(const std::string& topic_name,
-                      const ROSType& msg_type, const std::string& definition);
-
-  void registerParser(const std::string& topic_name,
-                      const RosMsgParser::ShapeShifter& msg);
-
-  void registerParser(const std::string& topic_name,
-                      const rosbag::ConnectionInfo &connection);
-
-  const Parser* getParser(const std::string& topic_name) const;
-
-  const DeserializedMsg *deserialize(const std::string& topic_name,
-                                     Span<const uint8_t> buffer);
-
-  const DeserializedMsg* deserialize(const std::string& topic_name,
-                                     const ShapeShifter &msg );
-
-  const DeserializedMsg* deserialize(const std::string& topic_name,
-                                     const rosbag::MessageInstance& msg );
-
-private:
-  struct CachedPack{
-    Parser parser;
-    DeserializedMsg msg;
-  };
-  std::unordered_map<std::string, CachedPack> _pack;
-  std::vector<uint8_t> _buffer;
-};
-
-//---------------------------------------------------
-
-template<typename T> inline
-T Parser::extractField(const Span<uint8_t> &buffer) const
-{
+  inline T Parser::extractField(const Span<uint8_t> &buffer) const
+  {
     T out;
     bool found = false;
 
-    const ROSType monitored_type (ros::message_traits::DataType<T>::value());
+    const ROSType monitored_type(ros::message_traits::DataType<T>::value());
 
-    std::function<void(const MessageTreeNode*)> recursiveImpl;
+    std::function<void(const MessageTreeNode *)> recursiveImpl;
     size_t buffer_offset = 0;
 
-    recursiveImpl = [&](const MessageTreeNode* msg_node)
+    recursiveImpl = [&](const MessageTreeNode *msg_node)
     {
-      if( found ) return;
+      if (found)
+        return;
 
-      const ROSMessage* msg_definition = msg_node->value();
-      const ROSType& msg_type = msg_definition->type();
+      const ROSMessage *msg_definition = msg_node->value();
+      const ROSType &msg_type = msg_definition->type();
 
       size_t index_m = 0;
 
-      if( msg_type == monitored_type  )
+      if (msg_type == monitored_type)
       {
-            ros::serialization::IStream is( buffer.data() + buffer_offset,
-                                            buffer.size() - buffer_offset );
-            ros::serialization::deserialize(is, out);
-            found = true;
-            return;
+        ros::serialization::IStream is(buffer.data() + buffer_offset,
+                                       buffer.size() - buffer_offset);
+        ros::serialization::deserialize(is, out);
+        found = true;
+        return;
       }
-       // subfields
-      for (const ROSField& field : msg_definition->fields() )
+      // subfields
+      for (const ROSField &field : msg_definition->fields())
       {
-        if(field.isConstant() ) continue;
+        if (field.isConstant())
+          continue;
 
-        const ROSType& field_type = field.type();
+        const ROSType &field_type = field.type();
 
         int32_t array_size = field.arraySize();
-        if( array_size == -1)
+        if (array_size == -1)
         {
-          ReadFromBuffer( buffer, buffer_offset, array_size );
+          ReadFromBuffer(buffer, buffer_offset, array_size);
         }
         //------------------------------------
-        if( field_type.isBuiltin() && field_type != monitored_type )
+        if (field_type.isBuiltin() && field_type != monitored_type)
         {
-            //fast skip
-            if( field_type.typeSize() >= 1 )
-            {
-                buffer_offset += field_type.typeSize() * array_size;
-            }
-            else{
-                ReadFromBufferToVariant( field_type.typeID(), buffer, buffer_offset );
-            }
+          // fast skip
+          if (field_type.typeSize() >= 1)
+          {
+            buffer_offset += field_type.typeSize() * array_size;
+          }
+          else
+          {
+            ReadFromBufferToVariant(field_type.typeID(), buffer, buffer_offset);
+          }
         }
         else
         {
-          for (int i=0; i<array_size; i++ )
+          for (int i = 0; i < array_size; i++)
           {
-            recursiveImpl( msg_node->child(index_m) );
-            if( found ) return;
+            recursiveImpl(msg_node->child(index_m));
+            if (found)
+              return;
           }
           index_m++;
         }
       } // end for fields
+    };  // end lambda
 
-    }; //end lambda
-
-    //start recursion
-    recursiveImpl( _message_info->message_tree.croot() );
+    // start recursion
+    recursiveImpl(_message_info->message_tree.croot());
 
     return out;
-}
-
-
+  }
 
 }
-

--- a/src/ros_parser.cpp
+++ b/src/ros_parser.cpp
@@ -1,25 +1,25 @@
 /***** MIT License ****
-*
-*   Copyright (c) 2016-2022 Davide Faconti
-*
-*   Permission is hereby granted, free of charge, to any person obtaining a copy
-*   of this software and associated documentation files (the "Software"), to deal
-*   in the Software without restriction, including without limitation the rights
-*   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-*   copies of the Software, and to permit persons to whom the Software is
-*   furnished to do so, subject to the following conditions:
-*
-*   The above copyright notice and this permission notice shall be included in all
-*   copies or substantial portions of the Software.
-*
-*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-*   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-*   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-*   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-*   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-*   SOFTWARE.
-*/
+ *
+ *   Copyright (c) 2016-2022 Davide Faconti
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
 
 #include <boost/algorithm/string.hpp>
 #include <boost/utility/string_ref.hpp>
@@ -34,429 +34,427 @@
 
 namespace RosMsgParser
 {
-inline bool operator==(const std::string& a, const boost::string_ref& b)
-{
-  return (a.size() == b.size() && std::strncmp(a.data(), b.data(), a.size()) == 0);
-}
-
-void Parser::registerMessage(const std::string& definition)
-{
-  const boost::regex msg_separation_regex("^\\s*=+\\n+");
-
-  std::vector<std::string> split;
-  std::vector<const ROSType*> all_types;
-
-  boost::split_regex(split, definition, msg_separation_regex);
-
-  _message_info->type_list.reserve(split.size());
-  _message_info->type_list.clear();
-
-  for (size_t i = 0; i < split.size(); ++i)
+  inline bool operator==(const std::string &a, const boost::string_ref &b)
   {
-    ROSMessage msg(split[i]);
-    if (i == 0)
+    return (a.size() == b.size() && std::strncmp(a.data(), b.data(), a.size()) == 0);
+  }
+
+  void Parser::registerMessage(const std::string &definition)
+  {
+    const boost::regex msg_separation_regex("^\\s*=+\\n+");
+
+    std::vector<std::string> split;
+    std::vector<const ROSType *> all_types;
+
+    boost::split_regex(split, definition, msg_separation_regex);
+
+    _message_info->type_list.reserve(split.size());
+    _message_info->type_list.clear();
+
+    for (size_t i = 0; i < split.size(); ++i)
     {
-      msg.mutateType(_msg_type);
+      ROSMessage msg(split[i]);
+      if (i == 0)
+      {
+        msg.mutateType(_msg_type);
+      }
+
+      _message_info->type_list.push_back(std::move(msg));
+      all_types.push_back(&(_message_info->type_list.back().type()));
     }
 
-    _message_info->type_list.push_back(std::move(msg));
-    all_types.push_back(&(_message_info->type_list.back().type()));
-  }
-
-  for (ROSMessage& msg : _message_info->type_list)
-  {
-    msg.updateMissingPkgNames(all_types);
-  }
-  //------------------------------
-
-  std::function<void(const ROSMessage*, FieldTreeNode*, MessageTreeNode*)> recursiveTreeCreator;
-
-  recursiveTreeCreator = [&](const ROSMessage* msg_definition, FieldTreeNode* field_node, MessageTreeNode* msg_node) {
-    // note: should use reserve here, NOT resize
-    const size_t NUM_FIELDS = msg_definition->fields().size();
-
-    field_node->children().reserve(NUM_FIELDS);
-    msg_node->children().reserve(NUM_FIELDS);
-
-    for (const ROSField& field : msg_definition->fields())
+    for (ROSMessage &msg : _message_info->type_list)
     {
-      if (field.isConstant())
-      {
-        continue;
-      }
-      // Let's add first a child to string_node
-      field_node->addChild(&field);
-      FieldTreeNode* new_string_node = &(field_node->children().back());
-
-      const ROSMessage* next_msg = nullptr;
-      // builtin types will not trigger a recursion
-      if (field.type().isBuiltin() == false)
-      {
-        next_msg = getMessageByType(field.type());
-        if (next_msg == nullptr)
-        {
-          throw std::runtime_error("This type was not registered ");
-        }
-        msg_node->addChild(next_msg);
-        MessageTreeNode* new_msg_node = &(msg_node->children().back());
-        recursiveTreeCreator(next_msg, new_string_node, new_msg_node);
-
-      }  // end of field.isConstant()
-    }    // end of for fields
-  };     // end of lambda
-
-  auto& first_msg_type = _message_info->type_list.front();
-  _message_info->message_tree.root()->setValue(&first_msg_type);
-  _message_info->field_tree.root()->setValue( _dummy_root_field.get() );
-
-  // start recursion
-  recursiveTreeCreator(&_message_info->type_list.front(), _message_info->field_tree.root(),
-                       _message_info->message_tree.root());
-}
-
-Parser::Parser(const std::string &topic_name, const ROSType &msg_type, const std::string &definition)
-  : _message_info( new ROSMessageInfo)
-  , _global_warnings(&std::cerr)
-  , _topic_name(topic_name)
-  , _msg_type(msg_type)
-  , _discard_large_array(DISCARD_LARGE_ARRAYS)
-  , _max_array_size(100)
-  , _blob_policy(STORE_BLOB_AS_COPY)
-  , _dummy_root_field( new ROSField(_msg_type, topic_name) )
-{
-  registerMessage(definition);
-}
-
-const std::shared_ptr<ROSMessageInfo>& Parser::getMessageInfo() const
-{
-  return _message_info;
-}
-
-const ROSMessage* Parser::getMessageByType(const ROSType& type) const
-{
-  for (const ROSMessage& msg : _message_info->type_list)  // find in the list
-  {
-    if (msg.type() == type)
-    {
-      return &msg;
+      msg.updateMissingPkgNames(all_types);
     }
-  }
-  return nullptr;
-}
+    //------------------------------
 
-void Parser::applyVisitorToBuffer(const ROSType& target_type, Span<uint8_t>& buffer,
-                                  Parser::VisitingCallback callback) const
-{
-  if (getMessageByType(target_type) == nullptr)
+    std::function<void(const ROSMessage *, FieldTreeNode *, MessageTreeNode *)> recursiveTreeCreator;
+
+    recursiveTreeCreator = [&](const ROSMessage *msg_definition, FieldTreeNode *field_node, MessageTreeNode *msg_node)
+    {
+      // note: should use reserve here, NOT resize
+      const size_t NUM_FIELDS = msg_definition->fields().size();
+
+      field_node->children().reserve(NUM_FIELDS);
+      msg_node->children().reserve(NUM_FIELDS);
+
+      for (const ROSField &field : msg_definition->fields())
+      {
+        if (field.isConstant())
+        {
+          continue;
+        }
+        // Let's add first a child to string_node
+        field_node->addChild(&field);
+        FieldTreeNode *new_string_node = &(field_node->children().back());
+
+        const ROSMessage *next_msg = nullptr;
+        // builtin types will not trigger a recursion
+        if (field.type().isBuiltin() == false)
+        {
+          next_msg = getMessageByType(field.type());
+          if (next_msg == nullptr)
+          {
+            throw std::runtime_error("This type was not registered ");
+          }
+          msg_node->addChild(next_msg);
+          MessageTreeNode *new_msg_node = &(msg_node->children().back());
+          recursiveTreeCreator(next_msg, new_string_node, new_msg_node);
+
+        } // end of field.isConstant()
+      }   // end of for fields
+    };    // end of lambda
+
+    auto &first_msg_type = _message_info->type_list.front();
+    _message_info->message_tree.root()->setValue(&first_msg_type);
+    _message_info->field_tree.root()->setValue(_dummy_root_field.get());
+
+    // start recursion
+    recursiveTreeCreator(&_message_info->type_list.front(), _message_info->field_tree.root(),
+                         _message_info->message_tree.root());
+  }
+
+  Parser::Parser(const std::string &topic_name, const ROSType &msg_type, const std::string &definition)
+      : _message_info(new ROSMessageInfo), _global_warnings(&std::cerr), _topic_name(topic_name), _msg_type(msg_type), _discard_large_array(DISCARD_LARGE_ARRAYS), _max_array_size(100), _blob_policy(STORE_BLOB_AS_COPY), _dummy_root_field(new ROSField(_msg_type, topic_name))
   {
-    // you will not find it. Skip it;
-    return;
+    registerMessage(definition);
   }
 
-  std::function<void(const MessageTreeNode*)> recursiveImpl;
-  size_t buffer_offset = 0;
+  const std::shared_ptr<ROSMessageInfo> &Parser::getMessageInfo() const
+  {
+    return _message_info;
+  }
 
-  recursiveImpl = [&](const MessageTreeNode* msg_node) {
-    const ROSMessage* msg_definition = msg_node->value();
-    const ROSType& msg_type = msg_definition->type();
-
-    const bool matching = (msg_type == target_type);
-
-    uint8_t* prev_buffer_ptr = buffer.data() + buffer_offset;
-    size_t prev_offset = buffer_offset;
-
-    size_t index_m = 0;
-
-    for (const ROSField& field : msg_definition->fields())
+  const ROSMessage *Parser::getMessageByType(const ROSType &type) const
+  {
+    for (const ROSMessage &msg : _message_info->type_list) // find in the list
     {
-      if (field.isConstant())
-        continue;
-
-      const ROSType& field_type = field.type();
-
-      int32_t array_size = field.arraySize();
-      if (array_size == -1)
+      if (msg.type() == type)
       {
-        ReadFromBuffer(buffer, buffer_offset, array_size);
+        return &msg;
       }
-
-      //------------------------------------
-
-      if (field_type.isBuiltin())
-      {
-        for (int i = 0; i < array_size; i++)
-        {
-          // Skip
-          ReadFromBufferToVariant(field_type.typeID(), buffer, buffer_offset);
-        }
-      }
-      else
-      {
-        // field_type.typeID() == OTHER
-        for (int i = 0; i < array_size; i++)
-        {
-          recursiveImpl(msg_node->child(index_m));
-        }
-        index_m++;
-      }
-    }  // end for fields
-    if (matching)
-    {
-      Span<uint8_t> view(prev_buffer_ptr, buffer_offset - prev_offset);
-      callback(msg_type, view);
     }
-  };  // end lambda
-
-  // start recursion
-  recursiveImpl(_message_info->message_tree.croot());
-}
-
-template <typename Container>
-inline void ExpandVectorIfNecessary(Container& container, size_t new_size)
-{
-  if (container.size() <= new_size)
-  {
-    const size_t increased_size = std::max(size_t(32), container.size() * 2);
-    container.resize(increased_size);
+    return nullptr;
   }
-}
 
-bool Parser::deserializeIntoFlatMsg(Span<const uint8_t> buffer, FlatMessage* flat_container) const
-{
-  bool entire_message_parse = true;
-
-  size_t value_index = 0;
-  size_t name_index = 0;
-  size_t blob_index = 0;
-  size_t blob_storage_index = 0;
-
-  size_t buffer_offset = 0;
-
-  std::function<void(const MessageTreeNode*, FieldTreeLeaf, bool)> deserializeImpl;
-
-  deserializeImpl = [&](const MessageTreeNode* msg_node, FieldTreeLeaf tree_leaf, bool store) {
-    const ROSMessage* msg_definition = msg_node->value();
-    size_t index_s = 0;
-    size_t index_m = 0;
-
-    for (const ROSField& field : msg_definition->fields())
+  void Parser::applyVisitorToBuffer(const ROSType &target_type, Span<uint8_t> &buffer,
+                                    Parser::VisitingCallback callback) const
+  {
+    if (getMessageByType(target_type) == nullptr)
     {
-      bool DO_STORE = store;
-      if (field.isConstant())
-        continue;
+      // you will not find it. Skip it;
+      return;
+    }
 
-      const ROSType& field_type = field.type();
+    std::function<void(const MessageTreeNode *)> recursiveImpl;
+    size_t buffer_offset = 0;
 
-      auto new_tree_leaf = tree_leaf;
-      new_tree_leaf.node_ptr = tree_leaf.node_ptr->child(index_s);
+    recursiveImpl = [&](const MessageTreeNode *msg_node)
+    {
+      const ROSMessage *msg_definition = msg_node->value();
+      const ROSType &msg_type = msg_definition->type();
 
-      int32_t array_size = field.arraySize();
-      if (array_size == -1)
+      const bool matching = (msg_type == target_type);
+
+      uint8_t *prev_buffer_ptr = buffer.data() + buffer_offset;
+      size_t prev_offset = buffer_offset;
+
+      size_t index_m = 0;
+
+      for (const ROSField &field : msg_definition->fields())
       {
-        ReadFromBuffer(buffer, buffer_offset, array_size);
-      }
-      if (field.isArray())
-      {
-        new_tree_leaf.index_array.push_back(0);
-      }
+        if (field.isConstant())
+          continue;
 
-      bool IS_BLOB = false;
+        const ROSType &field_type = field.type();
 
-      // Stop storing it if is NOT a blob and a very large array.
-      if (array_size > static_cast<int32_t>(_max_array_size) &&
-          field_type.typeID() == BuiltinType::OTHER)
-      {
-        if (builtinSize(field_type.typeID()) == 1)
+        int32_t array_size = field.arraySize();
+        if (array_size == -1)
         {
-          IS_BLOB = true;
+          ReadFromBuffer(buffer, buffer_offset, array_size);
+        }
+
+        //------------------------------------
+
+        if (field_type.isBuiltin())
+        {
+          for (int i = 0; i < array_size; i++)
+          {
+            // Skip
+            ReadFromBufferToVariant(field_type.typeID(), buffer, buffer_offset);
+          }
         }
         else
         {
-          if (_discard_large_array)
+          // field_type.typeID() == OTHER
+          for (int i = 0; i < array_size; i++)
           {
-            DO_STORE = false;
+            recursiveImpl(msg_node->child(index_m));
           }
-          entire_message_parse = false;
+          index_m++;
         }
-      }
-
-      if (IS_BLOB)  // special case. This is a "blob", typically an image, a map, pointcloud, etc.
+      } // end for fields
+      if (matching)
       {
-        ExpandVectorIfNecessary(flat_container->blob, blob_index);
-
-        if (buffer_offset + array_size > static_cast<std::size_t>(buffer.size()))
-        {
-          throw std::runtime_error("Buffer overrun in deserializeIntoFlatContainer (blob)");
-        }
-        if (DO_STORE)
-        {
-          flat_container->blob[blob_index].first = new_tree_leaf;
-          auto& blob = flat_container->blob[blob_index].second;
-          blob_index++;
-
-          if (_blob_policy == STORE_BLOB_AS_COPY)
-          {
-            ExpandVectorIfNecessary(flat_container->blob_storage, blob_storage_index);
-
-            auto& storage = flat_container->blob_storage[blob_storage_index];
-            storage.resize(array_size);
-            std::memcpy(storage.data(), &buffer[buffer_offset], array_size);
-            blob_storage_index++;
-
-            blob = Span<const uint8_t>(storage.data(), storage.size());
-          }
-          else
-          {
-            blob = Span<const uint8_t>(&buffer[buffer_offset], array_size);
-          }
-        }
-        buffer_offset += array_size;
+        Span<uint8_t> view(prev_buffer_ptr, buffer_offset - prev_offset);
+        callback(msg_type, view);
       }
-      else  // NOT a BLOB
-      {
-        bool DO_STORE_ARRAY = DO_STORE;
-        for (int i = 0; i < array_size; i++)
-        {
-          if (DO_STORE_ARRAY && i >= static_cast<int32_t>(_max_array_size))
-          {
-            DO_STORE_ARRAY = false;
-          }
+    }; // end lambda
 
-          if (field.isArray() && DO_STORE_ARRAY)
-          {
-            new_tree_leaf.index_array.back() = i;
-          }
-
-          if (field_type.typeID() == STRING)
-          {
-            ExpandVectorIfNecessary(flat_container->name, name_index);
-
-            uint32_t string_size = 0;
-            ReadFromBuffer(buffer, buffer_offset, string_size);
-
-            if (buffer_offset + string_size > static_cast<std::size_t>(buffer.size()))
-            {
-              throw std::runtime_error("Buffer overrun in RosMsgParser::ReadFromBuffer");
-            }
-
-            if (DO_STORE_ARRAY)
-            {
-              if (string_size == 0)
-              {
-                // corner case, when there is an empty string at the end of the message
-                flat_container->name[name_index].second.clear();
-              }
-              else
-              {
-                const char* buffer_ptr = reinterpret_cast<const char*>(buffer.data() + buffer_offset);
-                flat_container->name[name_index].second.assign(buffer_ptr, string_size);
-              }
-              flat_container->name[name_index].first = new_tree_leaf;
-              name_index++;
-            }
-            buffer_offset += string_size;
-          }
-          else if (field_type.isBuiltin())
-          {
-            ExpandVectorIfNecessary(flat_container->value, value_index);
-
-            Variant var = ReadFromBufferToVariant(field_type.typeID(), buffer, buffer_offset);
-            if (DO_STORE_ARRAY)
-            {
-              flat_container->value[value_index] = std::make_pair(new_tree_leaf, std::move(var));
-              value_index++;
-            }
-          }
-          else
-          {  // field_type.typeID() == OTHER
-
-            deserializeImpl(msg_node->child(index_m), new_tree_leaf, DO_STORE_ARRAY);
-          }
-        }  // end for array_size
-      }
-
-      if (field_type.typeID() == OTHER)
-      {
-        index_m++;
-      }
-      index_s++;
-    }  // end for fields
-  };   // end of lambda
-
-  // pass the shared_ptr
-  flat_container->msg_info = _message_info;
-
-  FieldTreeLeaf rootnode;
-  rootnode.node_ptr = _message_info->field_tree.croot();
-
-  deserializeImpl(_message_info->message_tree.croot(), rootnode, true);
-
-  flat_container->name.resize(name_index);
-  flat_container->value.resize(value_index);
-  flat_container->blob.resize(blob_index);
-  flat_container->blob_storage.resize(blob_storage_index);
-
-  if (buffer_offset != static_cast<std::size_t>(buffer.size()))
-  {
-    char msg_buff[1000];
-    sprintf(msg_buff,
-            "buildRosFlatType: There was an error parsing the buffer.\n"
-            "Size %d != %d, while parsing [%s]",
-            (int)buffer_offset, (int)buffer.size(), _topic_name.c_str());
-
-    throw std::runtime_error(msg_buff);
+    // start recursion
+    recursiveImpl(_message_info->message_tree.croot());
   }
-  return entire_message_parse;
-}
 
-bool Parser::deserializeIntoJson(Span<const uint8_t> buffer, std::string* json_txt, bool pretty_printer) const
-{
-  rapidjson::Document json_document;
-  rapidjson::Document::AllocatorType& alloc = json_document.GetAllocator();
-
-  size_t buffer_offset = 0;
-
-  std::function<void(const MessageTreeNode*, rapidjson::Value&)> deserializeImpl;
-
-  deserializeImpl = [&](const MessageTreeNode* msg_node, rapidjson::Value& json_value) {
-    const ROSMessage* msg_definition = msg_node->value();
-    size_t index_s = 0;
-    size_t index_m = 0;
-
-    for (const ROSField& field : msg_definition->fields())
+  template <typename Container>
+  inline void ExpandVectorIfNecessary(Container &container, size_t new_size)
+  {
+    if (container.size() <= new_size)
     {
-      if (field.isConstant())
-        continue;
+      const size_t increased_size = std::max(size_t(32), container.size() * 2);
+      container.resize(increased_size);
+    }
+  }
 
-      const ROSType& field_type = field.type();
-      auto field_name = rapidjson::StringRef(field.name().data(), field.name().size());
+  bool Parser::deserializeIntoFlatMsg(Span<const uint8_t> buffer, FlatMessage *flat_container) const
+  {
+    bool entire_message_parse = true;
 
-      int32_t array_size = field.arraySize();
-      if (array_size == -1)
+    size_t value_index = 0;
+    size_t name_index = 0;
+    size_t blob_index = 0;
+    size_t blob_storage_index = 0;
+
+    size_t buffer_offset = 0;
+
+    std::function<void(const MessageTreeNode *, FieldTreeLeaf, bool)> deserializeImpl;
+
+    deserializeImpl = [&](const MessageTreeNode *msg_node, FieldTreeLeaf tree_leaf, bool store)
+    {
+      const ROSMessage *msg_definition = msg_node->value();
+      size_t index_s = 0;
+      size_t index_m = 0;
+
+      for (const ROSField &field : msg_definition->fields())
       {
-        ReadFromBuffer(buffer, buffer_offset, array_size);
-      }
+        bool DO_STORE = store;
+        if (field.isConstant())
+          continue;
 
-      // Stop storing if it is a blob.
-      if (array_size > static_cast<int32_t>(_max_array_size))
-      {
-        if (buffer_offset + array_size > static_cast<std::size_t>(buffer.size()))
+        const ROSType &field_type = field.type();
+
+        auto new_tree_leaf = tree_leaf;
+        new_tree_leaf.node_ptr = tree_leaf.node_ptr->child(index_s);
+
+        int32_t array_size = field.arraySize();
+        if (array_size == -1)
         {
-          throw std::runtime_error("Buffer overrun in blob");
+          ReadFromBuffer(buffer, buffer_offset, array_size);
         }
-        buffer_offset += array_size;
-      }
-      else  // NOT a BLOB
-      {
-        rapidjson::Value array_value(rapidjson::kArrayType);
-
-        for (int i = 0; i < array_size; i++)
+        if (field.isArray())
         {
-          rapidjson::Value new_value;
-          new_value.SetObject();
+          new_tree_leaf.index_array.push_back(0);
+        }
 
-          switch (field_type.typeID())
+        bool IS_BLOB = false;
+
+        // Stop storing it if is NOT a blob and a very large array.
+        if (array_size > static_cast<int32_t>(_max_array_size) &&
+            field_type.typeID() == BuiltinType::OTHER)
+        {
+          if (builtinSize(field_type.typeID()) == 1)
           {
+            IS_BLOB = true;
+          }
+          else
+          {
+            if (_discard_large_array)
+            {
+              DO_STORE = false;
+            }
+            entire_message_parse = false;
+          }
+        }
+
+        if (IS_BLOB) // special case. This is a "blob", typically an image, a map, pointcloud, etc.
+        {
+          ExpandVectorIfNecessary(flat_container->blob, blob_index);
+
+          if (buffer_offset + array_size > static_cast<std::size_t>(buffer.size()))
+          {
+            throw std::runtime_error("Buffer overrun in deserializeIntoFlatContainer (blob)");
+          }
+          if (DO_STORE)
+          {
+            flat_container->blob[blob_index].first = new_tree_leaf;
+            auto &blob = flat_container->blob[blob_index].second;
+            blob_index++;
+
+            if (_blob_policy == STORE_BLOB_AS_COPY)
+            {
+              ExpandVectorIfNecessary(flat_container->blob_storage, blob_storage_index);
+
+              auto &storage = flat_container->blob_storage[blob_storage_index];
+              storage.resize(array_size);
+              std::memcpy(storage.data(), &buffer[buffer_offset], array_size);
+              blob_storage_index++;
+
+              blob = Span<const uint8_t>(storage.data(), storage.size());
+            }
+            else
+            {
+              blob = Span<const uint8_t>(&buffer[buffer_offset], array_size);
+            }
+          }
+          buffer_offset += array_size;
+        }
+        else // NOT a BLOB
+        {
+          bool DO_STORE_ARRAY = DO_STORE;
+          for (int i = 0; i < array_size; i++)
+          {
+            if (DO_STORE_ARRAY && i >= static_cast<int32_t>(_max_array_size))
+            {
+              DO_STORE_ARRAY = false;
+            }
+
+            if (field.isArray() && DO_STORE_ARRAY)
+            {
+              new_tree_leaf.index_array.back() = i;
+            }
+
+            if (field_type.typeID() == STRING)
+            {
+              ExpandVectorIfNecessary(flat_container->name, name_index);
+
+              uint32_t string_size = 0;
+              ReadFromBuffer(buffer, buffer_offset, string_size);
+
+              if (buffer_offset + string_size > static_cast<std::size_t>(buffer.size()))
+              {
+                throw std::runtime_error("Buffer overrun in RosMsgParser::ReadFromBuffer");
+              }
+
+              if (DO_STORE_ARRAY)
+              {
+                if (string_size == 0)
+                {
+                  // corner case, when there is an empty string at the end of the message
+                  flat_container->name[name_index].second.clear();
+                }
+                else
+                {
+                  const char *buffer_ptr = reinterpret_cast<const char *>(buffer.data() + buffer_offset);
+                  flat_container->name[name_index].second.assign(buffer_ptr, string_size);
+                }
+                flat_container->name[name_index].first = new_tree_leaf;
+                name_index++;
+              }
+              buffer_offset += string_size;
+            }
+            else if (field_type.isBuiltin())
+            {
+              ExpandVectorIfNecessary(flat_container->value, value_index);
+
+              Variant var = ReadFromBufferToVariant(field_type.typeID(), buffer, buffer_offset);
+              if (DO_STORE_ARRAY)
+              {
+                flat_container->value[value_index] = std::make_pair(new_tree_leaf, std::move(var));
+                value_index++;
+              }
+            }
+            else
+            { // field_type.typeID() == OTHER
+
+              deserializeImpl(msg_node->child(index_m), new_tree_leaf, DO_STORE_ARRAY);
+            }
+          } // end for array_size
+        }
+
+        if (field_type.typeID() == OTHER)
+        {
+          index_m++;
+        }
+        index_s++;
+      } // end for fields
+    };  // end of lambda
+
+    // pass the shared_ptr
+    flat_container->msg_info = _message_info;
+
+    FieldTreeLeaf rootnode;
+    rootnode.node_ptr = _message_info->field_tree.croot();
+
+    deserializeImpl(_message_info->message_tree.croot(), rootnode, true);
+
+    flat_container->name.resize(name_index);
+    flat_container->value.resize(value_index);
+    flat_container->blob.resize(blob_index);
+    flat_container->blob_storage.resize(blob_storage_index);
+
+    if (buffer_offset != static_cast<std::size_t>(buffer.size()))
+    {
+      char msg_buff[1000];
+      sprintf(msg_buff,
+              "buildRosFlatType: There was an error parsing the buffer.\n"
+              "Size %d != %d, while parsing [%s]",
+              (int)buffer_offset, (int)buffer.size(), _topic_name.c_str());
+
+      throw std::runtime_error(msg_buff);
+    }
+    return entire_message_parse;
+  }
+
+  bool Parser::deserializeIntoJson(Span<const uint8_t> buffer, std::string *json_txt, bool pretty_printer, bool combineSecNsec) const
+  {
+
+    rapidjson::Document json_document;
+    rapidjson::Document::AllocatorType &alloc = json_document.GetAllocator();
+
+    size_t buffer_offset = 0;
+
+    std::function<void(const MessageTreeNode *, rapidjson::Value &)> deserializeImpl;
+
+    deserializeImpl = [&](const MessageTreeNode *msg_node, rapidjson::Value &json_value)
+    {
+      const ROSMessage *msg_definition = msg_node->value();
+      size_t index_s = 0;
+      size_t index_m = 0;
+
+      for (const ROSField &field : msg_definition->fields())
+      {
+        if (field.isConstant())
+          continue;
+
+        const ROSType &field_type = field.type();
+        auto field_name = rapidjson::StringRef(field.name().data(), field.name().size());
+
+        int32_t array_size = field.arraySize();
+        if (array_size == -1)
+        {
+          ReadFromBuffer(buffer, buffer_offset, array_size);
+        }
+
+        // Stop storing if it is a blob.
+        if (array_size > static_cast<int32_t>(_max_array_size))
+        {
+          if (buffer_offset + array_size > static_cast<std::size_t>(buffer.size()))
+          {
+            throw std::runtime_error("Buffer overrun in blob");
+          }
+          buffer_offset += array_size;
+        }
+        else // NOT a BLOB
+        {
+          rapidjson::Value array_value(rapidjson::kArrayType);
+
+          for (int i = 0; i < array_size; i++)
+          {
+            rapidjson::Value new_value;
+            new_value.SetObject();
+
+            switch (field_type.typeID())
+            {
             case BOOL:
               new_value.SetBool(ReadFromBuffer<bool>(buffer, buffer_offset));
               break;
@@ -500,17 +498,53 @@ bool Parser::deserializeIntoJson(Span<const uint8_t> buffer, std::string* json_t
             case TIME:
             {
               ros::Time tmp;
-              ReadFromBuffer(buffer, buffer_offset, tmp.sec);
-              ReadFromBuffer(buffer, buffer_offset, tmp.nsec);
-              new_value.SetDouble(tmp.toSec());
+              if (combineSecNsec)
+              {
+                ReadFromBuffer(buffer, buffer_offset, tmp.sec);
+                ReadFromBuffer(buffer, buffer_offset, tmp.nsec);
+                new_value.SetDouble(tmp.toSec());
+              }
+              else
+              {
+                ReadFromBuffer(buffer, buffer_offset, tmp.sec);
+                ReadFromBuffer(buffer, buffer_offset, tmp.nsec);
+
+                rapidjson::Value sec_Value;
+                sec_Value.SetObject();
+                sec_Value.SetFloat(tmp.sec);
+                new_value.AddMember("secs", sec_Value, alloc);
+
+                rapidjson::Value nsec_value;
+                nsec_value.SetObject();
+                nsec_value.SetFloat(tmp.nsec);
+                new_value.AddMember("nsecs", nsec_value, alloc);
+              }
             }
             break;
             case DURATION:
             {
-              ros::Duration tmp;
-              ReadFromBuffer(buffer, buffer_offset, tmp.sec);
-              ReadFromBuffer(buffer, buffer_offset, tmp.nsec);
-              new_value.SetDouble(tmp.toSec());
+              ros::Time tmp;
+              if (combineSecNsec)
+              {
+                ReadFromBuffer(buffer, buffer_offset, tmp.sec);
+                ReadFromBuffer(buffer, buffer_offset, tmp.nsec);
+                new_value.SetDouble(tmp.toSec());
+              }
+              else
+              {
+                ReadFromBuffer(buffer, buffer_offset, tmp.sec);
+                ReadFromBuffer(buffer, buffer_offset, tmp.nsec);
+
+                rapidjson::Value sec_Value;
+                sec_Value.SetObject();
+                sec_Value.SetFloat(tmp.sec);
+                new_value.AddMember("secs", sec_Value, alloc);
+
+                rapidjson::Value nsec_value;
+                nsec_value.SetObject();
+                nsec_value.SetFloat(tmp.nsec);
+                new_value.AddMember("nsecs", nsec_value, alloc);
+              }
             }
             break;
 
@@ -522,7 +556,7 @@ bool Parser::deserializeIntoJson(Span<const uint8_t> buffer, std::string* json_t
               {
                 throw std::runtime_error("Buffer overrun");
               }
-              new_value.SetString(reinterpret_cast<const char*>(&buffer[buffer_offset]), string_size, alloc);
+              new_value.SetString(reinterpret_cast<const char *>(&buffer[buffer_offset]), string_size, alloc);
               buffer_offset += string_size;
             }
             break;
@@ -531,167 +565,519 @@ bool Parser::deserializeIntoJson(Span<const uint8_t> buffer, std::string* json_t
               deserializeImpl(msg_node->child(index_m), new_value);
             }
             break;
-          }  // end switch
+            } // end switch
+
+            if (field.isArray())
+            {
+              array_value.PushBack(new_value, alloc);
+            }
+            else
+            {
+              json_value.AddMember(field_name, new_value, alloc);
+            }
+          } // end for array
 
           if (field.isArray())
           {
-            array_value.PushBack(new_value, alloc);
+            json_value.AddMember(field_name, array_value, alloc);
           }
-          else
-          {
-            json_value.AddMember(field_name, new_value, alloc);
-          }
-        }  // end for array
+        } // end for array_size
 
-        if (field.isArray())
+        if (field_type.typeID() == OTHER)
         {
-          json_value.AddMember(field_name, array_value, alloc);
+          index_m++;
         }
-      }  // end for array_size
+        index_s++;
+      } // end for fields
+    };  // end of lambda
 
-      if (field_type.typeID() == OTHER)
+    // pass the shared_ptr
+
+    FieldTreeLeaf rootnode;
+    rootnode.node_ptr = _message_info->field_tree.croot();
+
+    json_document.SetObject();
+    rapidjson::Value json_node;
+    json_node.SetObject();
+
+    deserializeImpl(_message_info->message_tree.croot(), json_node);
+
+    auto topic_name = rapidjson::StringRef(_topic_name.data(), _topic_name.size());
+    json_document.AddMember("topic", topic_name, alloc);
+    json_document.AddMember("msg", json_node, alloc);
+
+    rapidjson::StringBuffer json_buffer;
+    json_buffer.Reserve(2048);
+
+    if (pretty_printer)
+    {
+      rapidjson::PrettyWriter<rapidjson::StringBuffer,
+                              rapidjson::UTF8<>,
+                              rapidjson::UTF8<>,
+                              rapidjson::CrtAllocator,
+                              rapidjson::kWriteDefaultFlags |
+                                  rapidjson::kWriteNanAndInfFlag>
+          json_writer(json_buffer);
+      json_document.Accept(json_writer);
+    }
+    else
+    {
+      rapidjson::Writer<rapidjson::StringBuffer,
+                        rapidjson::UTF8<>,
+                        rapidjson::UTF8<>,
+                        rapidjson::CrtAllocator,
+                        rapidjson::kWriteDefaultFlags |
+                            rapidjson::kWriteNanAndInfFlag>
+          json_writer(json_buffer);
+      json_document.Accept(json_writer);
+    }
+    *json_txt = json_buffer.GetString();
+
+    return true;
+  }
+
+  bool Parser::serializeFromJson(std::vector<uint8_t> &bufferOut, std::string *json_txt) const
+  {
+    rapidjson::Document json_document;
+    json_document.Parse(json_txt->c_str());
+    rapidjson::Document::AllocatorType &alloc = json_document.GetAllocator();
+
+
+    uint8_t *buffer_data;
+
+    size_t buffer_offset = 0;
+
+    std::function<void(const MessageTreeNode *, rapidjson::Value &)> deserializeImpl;
+    // rapidjson::Value new_value;
+
+    deserializeImpl = [&](const MessageTreeNode *msg_node, rapidjson::Value &new_value)
+    {
+      const ROSMessage *msg_definition = msg_node->value();
+      size_t index_s = 0;
+      size_t index_m = 0;
+
+      for (const ROSField &field : msg_definition->fields())
       {
-        index_m++;
-      }
-      index_s++;
-    }  // end for fields
-  };   // end of lambda
 
-  // pass the shared_ptr
+        // if (field.isConstant())
+        //   continue;
 
-  FieldTreeLeaf rootnode;
-  rootnode.node_ptr = _message_info->field_tree.croot();
+        const ROSType &field_type = field.type();
+        auto field_name = rapidjson::StringRef(field.name().data(), field.name().size());
 
-  json_document.SetObject();
-  rapidjson::Value json_node;
-  json_node.SetObject();
+        uint32_t array_size = field.arraySize();
 
-  deserializeImpl(_message_info->message_tree.croot(), json_node);
+        if (array_size == -1)
+        {
+          if (!new_value.HasMember(field_name.s))
+          {
+            throw std::runtime_error("looks like it is a blob that wasn't serialized");
+          }
 
-  auto topic_name = rapidjson::StringRef(_topic_name.data(), _topic_name.size());
-  json_document.AddMember("topic", topic_name, alloc);
-  json_document.AddMember("msg", json_node, alloc);
+          array_size = new_value[field_name.s].GetArray().Size();
+          buffer_data = reinterpret_cast<uint8_t *>(&array_size);
+          bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(uint32_t));
+        }
 
-  rapidjson::StringBuffer json_buffer;
-  json_buffer.Reserve(2048);
+        for (int i = 0; i < array_size; i++)
+        {
 
-  if( pretty_printer ){
-    rapidjson::PrettyWriter<rapidjson::StringBuffer,
-                            rapidjson::UTF8<>,
-                            rapidjson::UTF8<>,
-                            rapidjson::CrtAllocator,
-                            rapidjson::kWriteDefaultFlags |
-                              rapidjson::kWriteNanAndInfFlag> json_writer(json_buffer);
-    json_document.Accept(json_writer);
+          switch (field_type.typeID())
+          {
+          case BOOL:
+          {
+            bool val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetBool();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetBool();
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(bool));
+          }
+          break;
+          case CHAR:
+          {
+
+            char val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetString()[0];
+            }
+            else
+            {
+              val = new_value[field_name.s].GetString()[0];
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(char));
+          }
+          break;
+          case BYTE:
+          case UINT8:
+          {
+
+            uint8_t val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetUint();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetUint();
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(uint8_t));
+          }
+          break;
+          case UINT16:
+          {
+            uint16_t val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetUint();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetUint();
+            }
+
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(uint16_t));
+          }
+          break;
+          case UINT32:
+          {
+
+            uint32_t val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetUint();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetUint();
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(uint32_t));
+          }
+          break;
+          case UINT64:
+          {
+
+            uint64_t val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetUint64();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetUint64();
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(uint64_t));
+          }
+          break;
+          case INT8:
+          {
+            int8_t val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetInt();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetInt();
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(int8_t));
+          }
+          break;
+          case INT16:
+          {
+            int16_t val;
+
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetInt();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetInt();
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(int16_t));
+          }
+          break;
+          case INT32:
+          {
+            int32_t val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetInt();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetInt();
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(int32_t));
+          }
+          break;
+          case INT64:
+          {
+            int64_t val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetInt64();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetInt64();
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(int64_t));
+          }
+          break;
+          case FLOAT32:
+          {
+            float val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetFloat();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetFloat();
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(float));
+          }
+          break;
+          case FLOAT64:
+          {
+            double val;
+            if (new_value[field_name.s].IsArray())
+            {
+              val = new_value[field_name.s].GetArray()[i].GetDouble();
+            }
+            else
+            {
+              val = new_value[field_name.s].GetDouble();
+            }
+            buffer_data = reinterpret_cast<uint8_t *>(&val);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(double));
+          }
+          break;
+          case TIME:
+          {
+            if (new_value[field_name.s].IsObject())
+            {
+
+              float val = new_value[field_name.s].GetObject()["secs"].GetFloat();
+              buffer_data = reinterpret_cast<uint8_t *>(&val);
+              bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(float));
+
+              val = new_value[field_name.s].GetObject()["nsecs"].GetFloat();
+              buffer_data = reinterpret_cast<uint8_t *>(&val);
+              bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(float));
+            }
+            else
+            {
+
+              // this is only to ensure backward compatibility with the library, since the original
+              // deserializeIntoJson function sets the timestamp in the format {s.ns} instead of {secs:s, nsecs:ns}
+
+              int val = (int)new_value[field_name.s].GetFloat();
+              buffer_data = reinterpret_cast<uint8_t *>(&val);
+              bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(float));
+
+              val = (int)((new_value[field_name.s].GetFloat() - val) * 1000000000);
+              buffer_data = reinterpret_cast<uint8_t *>(&val);
+              bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(float));
+            }
+          }
+          break;
+          case DURATION:
+          {
+            if (new_value[field_name.s].IsObject())
+            {
+              float val = new_value[field_name.s].GetObject()["secs"].GetFloat();
+              buffer_data = reinterpret_cast<uint8_t *>(&val);
+              bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(float));
+
+              val = new_value[field_name.s].GetObject()["nsecs"].GetFloat();
+              buffer_data = reinterpret_cast<uint8_t *>(&val);
+              bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(float));
+            }
+            else
+            {
+
+              // this is only to ensure backward compatibility with the library, since the original
+              // deserializeIntoJson function sets the timestamp in the format {s.ns} instead of {secs:s, nsecs:ns}
+
+              int val = (int)new_value[field_name.s].GetFloat();
+              buffer_data = reinterpret_cast<uint8_t *>(&val);
+              bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(float));
+
+              val = (int)((new_value[field_name.s].GetFloat() - val) * 1000000000);
+              buffer_data = reinterpret_cast<uint8_t *>(&val);
+              bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(float));
+            }
+          }
+          break;
+
+          case STRING:
+          {
+
+            char *val;
+            uint32_t len;
+
+            if (new_value[field_name.s].IsArray())
+            {
+              val = (char *)new_value[field_name.s].GetArray()[i].GetString();
+              len = new_value[field_name.s].GetArray()[i].GetStringLength();
+            }
+            else
+            {
+              val = (char *)new_value[field_name.s].GetString();
+              len = new_value[field_name.s].GetStringLength();
+            }
+
+            buffer_data = reinterpret_cast<uint8_t *>(&len);
+            bufferOut.insert(bufferOut.end(), buffer_data, buffer_data + sizeof(uint32_t));
+
+            bufferOut.insert(bufferOut.end(), val, val + len);
+
+          }
+          break;
+          case OTHER:
+          {
+            rapidjson::Value new_value2 = new_value[field_name.s].GetObject();
+
+          
+            deserializeImpl(msg_node->child(index_m), new_value2);
+          }
+          break;
+          } // end switch
+
+        } // end for array
+
+        if (field_type.typeID() == OTHER)
+        {
+          index_m++;
+        }
+        index_s++;
+      } // end for fields
+    };  // end of lambda
+
+    // pass the shared_ptr
+
+    rapidjson::Value json_node;
+    json_node = json_document.GetObject();
+
+    deserializeImpl(_message_info->message_tree.croot(), json_node);
+
+    return true;
   }
-  else{
-    rapidjson::Writer<rapidjson::StringBuffer,
-                      rapidjson::UTF8<>,
-                      rapidjson::UTF8<>,
-                      rapidjson::CrtAllocator,
-                      rapidjson::kWriteDefaultFlags |
-                        rapidjson::kWriteNanAndInfFlag> json_writer(json_buffer);
-    json_document.Accept(json_writer);
-  }
-  *json_txt = json_buffer.GetString();
 
-  return true;
-}
-
-void CreateRenamedValues(const FlatMessage& flat_msg, RenamedValues& renamed)
-{
-  renamed.resize(flat_msg.value.size());
-  for (size_t i = 0; i < flat_msg.value.size(); i++)
+  void CreateRenamedValues(const FlatMessage &flat_msg, RenamedValues &renamed)
   {
-    const auto& in = flat_msg.value[i];
-    auto& out = renamed[i];
-    in.first.toStr(out.first);
-    out.second = in.second.convert<double>();
+    renamed.resize(flat_msg.value.size());
+    for (size_t i = 0; i < flat_msg.value.size(); i++)
+    {
+      const auto &in = flat_msg.value[i];
+      auto &out = renamed[i];
+      in.first.toStr(out.first);
+      out.second = in.second.convert<double>();
+    }
   }
-}
 
-void ParsersCollection::registerParser(const std::string& topic_name, const ROSType& msg_type,
-                                       const std::string& definition)
-{
-  auto it = _pack.find(topic_name);
-  if (it == _pack.end())
+  void ParsersCollection::registerParser(const std::string &topic_name, const ROSType &msg_type,
+                                         const std::string &definition)
   {
-    Parser parser(topic_name, msg_type, definition);
-    CachedPack pack = { std::move(parser), {} };
-    _pack.insert({ topic_name, std::move(pack) });
+    auto it = _pack.find(topic_name);
+    if (it == _pack.end())
+    {
+      Parser parser(topic_name, msg_type, definition);
+      CachedPack pack = {std::move(parser), {}};
+      _pack.insert({topic_name, std::move(pack)});
+    }
   }
-}
 
-void ParsersCollection::registerParser(const std::string& topic_name, const ShapeShifter& msg)
-{
-  registerParser(topic_name, msg.getDataType(), msg.getMessageDefinition());
-}
-
-void ParsersCollection::registerParser(const std::string& topic_name, const rosbag::ConnectionInfo& connection)
-{
-  registerParser(topic_name, connection.datatype, connection.msg_def);
-}
-
-const Parser* ParsersCollection::getParser(const std::string& topic_name) const
-{
-  auto it = _pack.find(topic_name);
-  if (it != _pack.end())
+  void ParsersCollection::registerParser(const std::string &topic_name, const ShapeShifter &msg)
   {
-    return &it->second.parser;
+    registerParser(topic_name, msg.getDataType(), msg.getMessageDefinition());
   }
-  return nullptr;
-}
 
-const ParsersCollection::DeserializedMsg* ParsersCollection::deserialize(const std::string& topic_name,
-                                                                         Span<const uint8_t> buffer)
-{
-  auto it = _pack.find(topic_name);
-  if (it != _pack.end())
+  void ParsersCollection::registerParser(const std::string &topic_name, const rosbag::ConnectionInfo &connection)
   {
-    CachedPack& pack = it->second;
-    Parser& parser = pack.parser;
-    FlatMessage& flat_msg = pack.msg.flat_msg;
-    RenamedValues& renamed = pack.msg.renamed_vals;
-
-    parser.deserializeIntoFlatMsg(buffer, &flat_msg);
-    CreateRenamedValues(flat_msg, renamed);
-
-    return &pack.msg;
+    registerParser(topic_name, connection.datatype, connection.msg_def);
   }
-  return nullptr;
-}
 
-const ParsersCollection::DeserializedMsg* ParsersCollection::deserialize(const std::string& topic_name,
-                                                                         const ShapeShifter& msg)
-{
-  Span<const uint8_t> buffer(msg.raw_data(), msg.size());
-  return deserialize(topic_name, buffer);
-}
-
-const ParsersCollection::DeserializedMsg* ParsersCollection::deserialize(const std::string& topic_name,
-                                                                         const rosbag::MessageInstance& msg)
-{
-  auto it = _pack.find(topic_name);
-  if (it != _pack.end())
+  const Parser *ParsersCollection::getParser(const std::string &topic_name) const
   {
-    CachedPack& pack = it->second;
-    Parser& parser = pack.parser;
-    FlatMessage& flat_msg = pack.msg.flat_msg;
-    RenamedValues& renamed = pack.msg.renamed_vals;
-
-    // write the message into the buffer
-    _buffer.resize(msg.size());
-    ros::serialization::OStream stream(_buffer.data(), msg.size());
-    msg.write(stream);
-
-    Span<const uint8_t> buffer(_buffer.data(), msg.size());
-
-    parser.deserializeIntoFlatMsg(buffer, &flat_msg);
-    CreateRenamedValues(flat_msg, renamed);
-
-    return &pack.msg;
+    auto it = _pack.find(topic_name);
+    if (it != _pack.end())
+    {
+      return &it->second.parser;
+    }
+    return nullptr;
   }
-  return nullptr;
-}
 
-}  // namespace RosMsgParser
+  const ParsersCollection::DeserializedMsg *ParsersCollection::deserialize(const std::string &topic_name,
+                                                                           Span<const uint8_t> buffer)
+  {
+    auto it = _pack.find(topic_name);
+    if (it != _pack.end())
+    {
+      CachedPack &pack = it->second;
+      Parser &parser = pack.parser;
+      FlatMessage &flat_msg = pack.msg.flat_msg;
+      RenamedValues &renamed = pack.msg.renamed_vals;
+
+      parser.deserializeIntoFlatMsg(buffer, &flat_msg);
+      CreateRenamedValues(flat_msg, renamed);
+
+      return &pack.msg;
+    }
+    return nullptr;
+  }
+
+  const ParsersCollection::DeserializedMsg *ParsersCollection::deserialize(const std::string &topic_name,
+                                                                           const ShapeShifter &msg)
+  {
+    Span<const uint8_t> buffer(msg.raw_data(), msg.size());
+    return deserialize(topic_name, buffer);
+  }
+
+  const ParsersCollection::DeserializedMsg *ParsersCollection::deserialize(const std::string &topic_name,
+                                                                           const rosbag::MessageInstance &msg)
+  {
+    auto it = _pack.find(topic_name);
+    if (it != _pack.end())
+    {
+      CachedPack &pack = it->second;
+      Parser &parser = pack.parser;
+      FlatMessage &flat_msg = pack.msg.flat_msg;
+      RenamedValues &renamed = pack.msg.renamed_vals;
+
+      // write the message into the buffer
+      _buffer.resize(msg.size());
+      ros::serialization::OStream stream(_buffer.data(), msg.size());
+      msg.write(stream);
+
+      Span<const uint8_t> buffer(_buffer.data(), msg.size());
+
+      parser.deserializeIntoFlatMsg(buffer, &flat_msg);
+      CreateRenamedValues(flat_msg, renamed);
+
+      return &pack.msg;
+    }
+    return nullptr;
+  }
+
+} // namespace RosMsgParser

--- a/tests/deserializer_test.cpp
+++ b/tests/deserializer_test.cpp
@@ -7,11 +7,15 @@
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/Image.h>
 #include <std_msgs/Int16MultiArray.h>
+#include <std_msgs/UInt8.h>
+#include <std_msgs/Int32.h>
+#include <std_msgs/Int64.h>
+#include <std_msgs/Char.h>
+#include <std_msgs/String.h>
 #include <geometry_msgs/PoseStamped.h>
 
 using namespace ros::message_traits;
 using namespace RosMsgParser;
-
 
 TEST(Deserialize, JointState)
 {
@@ -24,41 +28,44 @@ TEST(Deserialize, JointState)
   const int NUM = 15;
 
   joint_state.header.seq = 2016;
-  joint_state.header.stamp.sec  = 1234;
-  joint_state.header.stamp.nsec = 567*1000*1000;
+  joint_state.header.stamp.sec = 1234;
+  joint_state.header.stamp.nsec = 567 * 1000 * 1000;
   joint_state.header.frame_id = "pippo";
 
-  joint_state.name.resize( NUM );
-  joint_state.position.resize( NUM );
-  joint_state.velocity.resize( NUM );
-  joint_state.effort.resize( NUM );
+  joint_state.name.resize(NUM);
+  joint_state.position.resize(NUM);
+  joint_state.velocity.resize(NUM);
+  joint_state.effort.resize(NUM);
 
   std::string names[NUM];
   names[0] = ("hola");
   names[1] = ("ciao");
   names[2] = ("bye");
 
-  for (int i=0; i<NUM; i++)
+  for (int i = 0; i < NUM; i++)
   {
-    joint_state.name[i] = names[i%3];
-    joint_state.position[i]= 10+i;
-    joint_state.velocity[i]= 30+i;
-    joint_state.effort[i]= 50+i;
+    joint_state.name[i] = names[i % 3];
+    joint_state.position[i] = 10 + i;
+    joint_state.velocity[i] = 30 + i;
+    joint_state.effort[i] = 50 + i;
   }
 
-  std::vector<uint8_t> buffer( ros::serialization::serializationLength(joint_state) );
+  std::vector<uint8_t> buffer(ros::serialization::serializationLength(joint_state));
   ros::serialization::OStream stream(buffer.data(), buffer.size());
   ros::serialization::Serializer<sensor_msgs::JointState>::write(stream, joint_state);
 
   FlatMessage flat_container;
-  parser.deserializeIntoFlatMsg( Span<uint8_t>(buffer), &flat_container);
+  parser.deserializeIntoFlatMsg(Span<uint8_t>(buffer), &flat_container);
 
-  if(VERBOSE_TEST){
-    for(auto&it: flat_container.value) {
+  if (VERBOSE_TEST)
+  {
+    for (auto &it : flat_container.value)
+    {
       std::cout << it.first << " >> " << it.second.convert<double>() << std::endl;
     }
 
-    for(auto&it: flat_container.name) {
+    for (auto &it : flat_container.name)
+    {
       std::cout << it.first << " >> " << it.second << std::endl;
     }
   }
@@ -66,66 +73,64 @@ TEST(Deserialize, JointState)
   std::string json_txt;
   parser.deserializeIntoJson(Span<uint8_t>(buffer), &json_txt);
 
-  std::cout << json_txt << std::endl;
+  EXPECT_EQ(flat_container.value[0].first.toStdString(), ("/js_publisher/joint_state/header/seq"));
+  EXPECT_EQ(flat_container.value[0].second.convert<int>(), 2016);
+  EXPECT_EQ(flat_container.value[1].first.toStdString(), ("/js_publisher/joint_state/header/stamp"));
+  EXPECT_EQ(flat_container.value[1].second.convert<double>(), double(1234.567));
+  EXPECT_EQ(flat_container.value[1].second.convert<ros::Time>(), joint_state.header.stamp);
 
-  EXPECT_EQ( flat_container.value[0].first.toStdString() , ("/js_publisher/joint_state/header/seq"));
-  EXPECT_EQ( flat_container.value[0].second.convert<int>(), 2016 );
-  EXPECT_EQ( flat_container.value[1].first.toStdString() , ("/js_publisher/joint_state/header/stamp"));
-  EXPECT_EQ( flat_container.value[1].second.convert<double>(),   double(1234.567)  );
-  EXPECT_EQ( flat_container.value[1].second.convert<ros::Time>(), joint_state.header.stamp  );
+  EXPECT_EQ(flat_container.value[2].first.toStdString(), ("/js_publisher/joint_state/position.0"));
+  EXPECT_EQ(flat_container.value[2].second.convert<int>(), 10);
+  EXPECT_EQ(flat_container.value[3].first.toStdString(), ("/js_publisher/joint_state/position.1"));
+  EXPECT_EQ(flat_container.value[3].second.convert<int>(), 11);
+  EXPECT_EQ(flat_container.value[4].first.toStdString(), ("/js_publisher/joint_state/position.2"));
+  EXPECT_EQ(flat_container.value[4].second.convert<int>(), 12);
+  EXPECT_EQ(flat_container.value[16].first.toStdString(), ("/js_publisher/joint_state/position.14"));
+  EXPECT_EQ(flat_container.value[16].second.convert<int>(), 24);
 
-  EXPECT_EQ( flat_container.value[2].first.toStdString() , ("/js_publisher/joint_state/position.0"));
-  EXPECT_EQ( flat_container.value[2].second.convert<int>(), 10 );
-  EXPECT_EQ( flat_container.value[3].first.toStdString() , ("/js_publisher/joint_state/position.1"));
-  EXPECT_EQ( flat_container.value[3].second.convert<int>(), 11 );
-  EXPECT_EQ( flat_container.value[4].first.toStdString() , ("/js_publisher/joint_state/position.2"));
-  EXPECT_EQ( flat_container.value[4].second.convert<int>(), 12 );
-  EXPECT_EQ( flat_container.value[16].first.toStdString() , ("/js_publisher/joint_state/position.14"));
-  EXPECT_EQ( flat_container.value[16].second.convert<int>(), 24 );
+  EXPECT_EQ(flat_container.value[17].first.toStdString(), ("/js_publisher/joint_state/velocity.0"));
+  EXPECT_EQ(flat_container.value[17].second.convert<int>(), 30);
+  EXPECT_EQ(flat_container.value[18].first.toStdString(), ("/js_publisher/joint_state/velocity.1"));
+  EXPECT_EQ(flat_container.value[18].second.convert<int>(), 31);
+  EXPECT_EQ(flat_container.value[19].first.toStdString(), ("/js_publisher/joint_state/velocity.2"));
+  EXPECT_EQ(flat_container.value[19].second.convert<int>(), 32);
+  EXPECT_EQ(flat_container.value[31].first.toStdString(), ("/js_publisher/joint_state/velocity.14"));
+  EXPECT_EQ(flat_container.value[31].second.convert<int>(), 44);
 
-  EXPECT_EQ( flat_container.value[17].first.toStdString() , ("/js_publisher/joint_state/velocity.0"));
-  EXPECT_EQ( flat_container.value[17].second.convert<int>(), 30 );
-  EXPECT_EQ( flat_container.value[18].first.toStdString() , ("/js_publisher/joint_state/velocity.1"));
-  EXPECT_EQ( flat_container.value[18].second.convert<int>(), 31 );
-  EXPECT_EQ( flat_container.value[19].first.toStdString() , ("/js_publisher/joint_state/velocity.2"));
-  EXPECT_EQ( flat_container.value[19].second.convert<int>(), 32 );
-  EXPECT_EQ( flat_container.value[31].first.toStdString() , ("/js_publisher/joint_state/velocity.14"));
-  EXPECT_EQ( flat_container.value[31].second.convert<int>(), 44 );
+  EXPECT_EQ(flat_container.value[32].first.toStdString(), ("/js_publisher/joint_state/effort.0"));
+  EXPECT_EQ(flat_container.value[32].second.convert<int>(), 50);
+  EXPECT_EQ(flat_container.value[33].first.toStdString(), ("/js_publisher/joint_state/effort.1"));
+  EXPECT_EQ(flat_container.value[33].second.convert<int>(), 51);
+  EXPECT_EQ(flat_container.value[34].first.toStdString(), ("/js_publisher/joint_state/effort.2"));
+  EXPECT_EQ(flat_container.value[34].second.convert<int>(), 52);
+  EXPECT_EQ(flat_container.value[46].first.toStdString(), ("/js_publisher/joint_state/effort.14"));
+  EXPECT_EQ(flat_container.value[46].second.convert<int>(), 64);
 
-  EXPECT_EQ( flat_container.value[32].first.toStdString() , ("/js_publisher/joint_state/effort.0"));
-  EXPECT_EQ( flat_container.value[32].second.convert<int>(), 50 );
-  EXPECT_EQ( flat_container.value[33].first.toStdString() , ("/js_publisher/joint_state/effort.1"));
-  EXPECT_EQ( flat_container.value[33].second.convert<int>(), 51 );
-  EXPECT_EQ( flat_container.value[34].first.toStdString() , ("/js_publisher/joint_state/effort.2"));
-  EXPECT_EQ( flat_container.value[34].second.convert<int>(), 52 );
-  EXPECT_EQ( flat_container.value[46].first.toStdString() , ("/js_publisher/joint_state/effort.14"));
-  EXPECT_EQ( flat_container.value[46].second.convert<int>(), 64 );
+  EXPECT_EQ(flat_container.name[0].first.toStdString(), ("/js_publisher/joint_state/header/frame_id"));
+  EXPECT_EQ(flat_container.name[0].second, ("pippo"));
 
-  EXPECT_EQ( flat_container.name[0].first.toStdString() , ("/js_publisher/joint_state/header/frame_id"));
-  EXPECT_EQ( flat_container.name[0].second, ("pippo") );
-
-  EXPECT_EQ( flat_container.name[1].first.toStdString() , ("/js_publisher/joint_state/name.0"));
-  EXPECT_EQ( flat_container.name[1].second, ("hola") );
-  EXPECT_EQ( flat_container.name[2].first.toStdString() , ("/js_publisher/joint_state/name.1"));
-  EXPECT_EQ( flat_container.name[2].second, ("ciao") );
-  EXPECT_EQ( flat_container.name[3].first.toStdString() , ("/js_publisher/joint_state/name.2"));
-  EXPECT_EQ( flat_container.name[3].second, ("bye") );
+  EXPECT_EQ(flat_container.name[1].first.toStdString(), ("/js_publisher/joint_state/name.0"));
+  EXPECT_EQ(flat_container.name[1].second, ("hola"));
+  EXPECT_EQ(flat_container.name[2].first.toStdString(), ("/js_publisher/joint_state/name.1"));
+  EXPECT_EQ(flat_container.name[2].second, ("ciao"));
+  EXPECT_EQ(flat_container.name[3].first.toStdString(), ("/js_publisher/joint_state/name.2"));
+  EXPECT_EQ(flat_container.name[3].second, ("bye"));
 
   //---------------------------------
   std::vector<std_msgs::Header> headers;
 
-  Parser::VisitingCallback callbackReadAndStore = [&headers](const ROSType&, Span<uint8_t>& raw_data)
+  Parser::VisitingCallback callbackReadAndStore = [&headers](const ROSType &, Span<uint8_t> &raw_data)
   {
     std_msgs::Header msg;
-    ros::serialization::IStream s( raw_data.data(), raw_data.size() );
+    ros::serialization::IStream s(raw_data.data(), raw_data.size());
     ros::serialization::deserialize(s, msg);
-    headers.push_back( std::move(msg) );
+    headers.push_back(std::move(msg));
   };
 
-  Parser::VisitingCallback callbackOverwriteInPlace = [&headers](const ROSType&, Span<uint8_t>& raw_data)
+  Parser::VisitingCallback callbackOverwriteInPlace = [&headers](const ROSType &, Span<uint8_t> &raw_data)
   {
     std_msgs::Header msg;
-    ros::serialization::IStream is( raw_data.data(), raw_data.size() );
+    ros::serialization::IStream is(raw_data.data(), raw_data.size());
     ros::serialization::deserialize(is, msg);
 
     ASSERT_EQ(ros::serialization::serializationLength(msg), raw_data.size());
@@ -135,81 +140,261 @@ TEST(Deserialize, JointState)
     msg.stamp.sec = 1;
     msg.stamp.nsec = 2;
 
-    ros::serialization::OStream os( raw_data.data(), raw_data.size() );
+    ros::serialization::OStream os(raw_data.data(), raw_data.size());
     ros::serialization::serialize(os, msg);
 
     ASSERT_EQ(ros::serialization::serializationLength(msg), raw_data.size());
   };
 
-
   Span<uint8_t> buffer_view(buffer);
-  const ROSType header_type( DataType<std_msgs::Header>::value() );
+  const ROSType header_type(DataType<std_msgs::Header>::value());
 
-  parser.applyVisitorToBuffer( header_type, buffer_view, callbackReadAndStore);
+  parser.applyVisitorToBuffer(header_type, buffer_view, callbackReadAndStore);
 
   EXPECT_EQ(headers.size(), 1);
-  const std_msgs::Header& header = headers[0];
-  EXPECT_EQ(header.seq,        joint_state.header.seq);
-  EXPECT_EQ(header.stamp.sec,  joint_state.header.stamp.sec);
+  const std_msgs::Header &header = headers[0];
+  EXPECT_EQ(header.seq, joint_state.header.seq);
+  EXPECT_EQ(header.stamp.sec, joint_state.header.stamp.sec);
   EXPECT_EQ(header.stamp.nsec, joint_state.header.stamp.nsec);
-  EXPECT_EQ(header.frame_id,   joint_state.header.frame_id);
+  EXPECT_EQ(header.frame_id, joint_state.header.frame_id);
   //--------------------------------------------
   parser.applyVisitorToBuffer(header_type, buffer_view, callbackOverwriteInPlace);
 
-  parser.applyVisitorToBuffer( header_type, buffer_view, callbackReadAndStore);
+  parser.applyVisitorToBuffer(header_type, buffer_view, callbackReadAndStore);
 
   EXPECT_EQ(headers.size(), 2);
-  const std_msgs::Header& header_mutated = headers[1];
-  EXPECT_EQ(header_mutated.seq,        666);
-  EXPECT_EQ(header_mutated.stamp.sec,  1);
+  const std_msgs::Header &header_mutated = headers[1];
+  EXPECT_EQ(header_mutated.seq, 666);
+  EXPECT_EQ(header_mutated.stamp.sec, 1);
   EXPECT_EQ(header_mutated.stamp.nsec, 2);
+}
+
+TEST(SerializeFromJson, JointState)
+{
+  RosMsgParser::Parser parser("/js_publisher/joint_state",
+                              ROSType(DataType<sensor_msgs::JointState>::value()),
+                              Definition<sensor_msgs::JointState>::value());
+
+  sensor_msgs::JointState joint_state;
+
+  const int NUM = 15;
+
+  joint_state.header.seq = 2016;
+  joint_state.header.stamp.sec = 1234;
+  joint_state.header.stamp.nsec = 567 * 1000 * 1000;
+  joint_state.header.frame_id = "pippo";
+
+  joint_state.name.resize(NUM);
+  joint_state.position.resize(NUM);
+  joint_state.velocity.resize(NUM);
+  joint_state.effort.resize(NUM);
+
+  std::string names[NUM];
+  names[0] = ("hola");
+  names[1] = ("ciao");
+  names[2] = ("bye");
+
+  for (int i = 0; i < NUM; i++)
+  {
+    joint_state.name[i] = names[i % 3];
+    joint_state.position[i] = 10 + i;
+    joint_state.velocity[i] = 30 + i;
+    joint_state.effort[i] = 50 + i;
+  }
+
+  std::vector<uint8_t> buffer(ros::serialization::serializationLength(joint_state));
+  ros::serialization::OStream stream(buffer.data(), buffer.size());
+  ros::serialization::Serializer<sensor_msgs::JointState>::write(stream, joint_state);
+
+  std::string json_txt;
+  parser.deserializeIntoJson(Span<uint8_t>(buffer), &json_txt, false);
+
+  // parse the string from format {topic:{t} , msg: {m}} into {m}
+  size_t startIdx = json_txt.find("msg");
+  if (startIdx != std::string::npos)
+  {
+    startIdx += 6; // Move past "(msg:)"
+
+    // Find the ending index before the last "}"
+    size_t endIdx = json_txt.rfind("}");
+    if (endIdx != std::string::npos)
+    {
+      // Extract the substring
+      json_txt = "{" + json_txt.substr(startIdx, endIdx - startIdx);
+    }
+    else
+    {
+      std::cerr << "Error: Unable to find the last '}'." << std::endl;
+    }
+  }
+  else
+  {
+    std::cerr << "Error: Unable to find '(msg:)'" << std::endl;
+  }
+
+  std::vector<uint8_t> bufferOut;
+  parser.serializeFromJson(bufferOut, &json_txt);
+  ros::serialization::IStream sstream(&bufferOut[0], bufferOut.size());
+  sensor_msgs::JointState joint_state_from_json;
+  ros::serialization::deserialize(sstream, joint_state_from_json);
+
+  FlatMessage flat_container;
+  parser.deserializeIntoFlatMsg(Span<uint8_t>(bufferOut), &flat_container);
+
+  if (VERBOSE_TEST)
+  {
+    for (auto &it : flat_container.value)
+    {
+      std::cout << it.first << " >> " << it.second.convert<double>() << std::endl;
+    }
+
+    for (auto &it : flat_container.name)
+    {
+      std::cout << it.first << " >> " << it.second << std::endl;
+    }
+  }
+
+  EXPECT_EQ(flat_container.value[0].first.toStdString(), ("/js_publisher/joint_state/header/seq"));
+  EXPECT_EQ(flat_container.value[0].second.convert<int>(), 2016);
+  EXPECT_EQ(flat_container.value[1].first.toStdString(), ("/js_publisher/joint_state/header/stamp"));
+  ASSERT_NEAR(flat_container.value[1].second.convert<double>(), double(1234.567), 0.001);
+  // due to serialization and deserialization, some fpu precision is lost
+  // EXPECT_EQ(flat_container.value[1].second.convert<double>(), double(1234.567));
+  // EXPECT_EQ(flat_container.value[1].second.convert<ros::Time>(), joint_state.header.stamp);
+
+  EXPECT_EQ(flat_container.value[2].first.toStdString(), ("/js_publisher/joint_state/position.0"));
+  EXPECT_EQ(flat_container.value[2].second.convert<int>(), 10);
+  EXPECT_EQ(flat_container.value[3].first.toStdString(), ("/js_publisher/joint_state/position.1"));
+  EXPECT_EQ(flat_container.value[3].second.convert<int>(), 11);
+  EXPECT_EQ(flat_container.value[4].first.toStdString(), ("/js_publisher/joint_state/position.2"));
+  EXPECT_EQ(flat_container.value[4].second.convert<int>(), 12);
+  EXPECT_EQ(flat_container.value[16].first.toStdString(), ("/js_publisher/joint_state/position.14"));
+  EXPECT_EQ(flat_container.value[16].second.convert<int>(), 24);
+
+  EXPECT_EQ(flat_container.value[17].first.toStdString(), ("/js_publisher/joint_state/velocity.0"));
+  EXPECT_EQ(flat_container.value[17].second.convert<int>(), 30);
+  EXPECT_EQ(flat_container.value[18].first.toStdString(), ("/js_publisher/joint_state/velocity.1"));
+  EXPECT_EQ(flat_container.value[18].second.convert<int>(), 31);
+  EXPECT_EQ(flat_container.value[19].first.toStdString(), ("/js_publisher/joint_state/velocity.2"));
+  EXPECT_EQ(flat_container.value[19].second.convert<int>(), 32);
+  EXPECT_EQ(flat_container.value[31].first.toStdString(), ("/js_publisher/joint_state/velocity.14"));
+  EXPECT_EQ(flat_container.value[31].second.convert<int>(), 44);
+
+  EXPECT_EQ(flat_container.value[32].first.toStdString(), ("/js_publisher/joint_state/effort.0"));
+  EXPECT_EQ(flat_container.value[32].second.convert<int>(), 50);
+  EXPECT_EQ(flat_container.value[33].first.toStdString(), ("/js_publisher/joint_state/effort.1"));
+  EXPECT_EQ(flat_container.value[33].second.convert<int>(), 51);
+  EXPECT_EQ(flat_container.value[34].first.toStdString(), ("/js_publisher/joint_state/effort.2"));
+  EXPECT_EQ(flat_container.value[34].second.convert<int>(), 52);
+  EXPECT_EQ(flat_container.value[46].first.toStdString(), ("/js_publisher/joint_state/effort.14"));
+  EXPECT_EQ(flat_container.value[46].second.convert<int>(), 64);
+
+  EXPECT_EQ(flat_container.name[0].first.toStdString(), ("/js_publisher/joint_state/header/frame_id"));
+  EXPECT_EQ(flat_container.name[0].second, ("pippo"));
+
+  EXPECT_EQ(flat_container.name[1].first.toStdString(), ("/js_publisher/joint_state/name.0"));
+  EXPECT_EQ(flat_container.name[1].second, ("hola"));
+  EXPECT_EQ(flat_container.name[2].first.toStdString(), ("/js_publisher/joint_state/name.1"));
+  EXPECT_EQ(flat_container.name[2].second, ("ciao"));
+  EXPECT_EQ(flat_container.name[3].first.toStdString(), ("/js_publisher/joint_state/name.2"));
+  EXPECT_EQ(flat_container.name[3].second, ("bye"));
+}
+
+TEST(SerializeFromJson, INT8)
+{
+
+  std::vector<uint8_t> bufferOut;
+
+  std_msgs::UInt8 m;
+  m.data = 23;
+
+  std::vector<uint8_t> buffer(ros::serialization::serializationLength(m));
+  ros::serialization::OStream stream2(buffer.data(), buffer.size());
+  ros::serialization::Serializer<std_msgs::UInt8>::write(stream2, m);
+  std::string json_txt;
+
+  RosMsgParser::Parser parser("",
+                              ROSType(DataType<std_msgs::UInt8>::value()),
+                              Definition<std_msgs::UInt8>::value());
+  parser.deserializeIntoJson(Span<uint8_t>(buffer), &json_txt);
+
+  size_t startIdx = json_txt.find("msg");
+  if (startIdx != std::string::npos)
+  {
+    startIdx += 6; // Move past "(msg:)"
+
+    // Find the ending index before the last "}"
+    size_t endIdx = json_txt.rfind("}");
+    if (endIdx != std::string::npos)
+    {
+      // Extract the substring
+      json_txt = "{" + json_txt.substr(startIdx, endIdx - startIdx);
+    }
+    else
+    {
+      std::cerr << "Error: Unable to find the last '}'." << std::endl;
+    }
+  }
+  else
+  {
+    std::cerr << "Error: Unable to find '(msg:)'" << std::endl;
+  }
+
+  parser.serializeFromJson(bufferOut, &json_txt);
+  ros::serialization::IStream sstream(&bufferOut[0], bufferOut.size());
+  std_msgs::UInt8 m2;
+  ros::serialization::deserialize(sstream, m2);
+  EXPECT_EQ(m2.data, 23);
 
 }
 
-TEST( Deserialize, NavSatStatus)
+TEST(Deserialize, NavSatStatus)
 {
   // We test this because we want to test that constant fields are skipped.
   RosMsgParser::Parser parser("nav_stat",
-        ROSType(DataType<sensor_msgs::NavSatStatus>::value()),
-        Definition<sensor_msgs::NavSatStatus>::value());
+                              ROSType(DataType<sensor_msgs::NavSatStatus>::value()),
+                              Definition<sensor_msgs::NavSatStatus>::value());
 
   sensor_msgs::NavSatStatus nav_stat;
-  nav_stat.status  = nav_stat.STATUS_GBAS_FIX;  // 2
+  nav_stat.status = nav_stat.STATUS_GBAS_FIX;  // 2
   nav_stat.service = nav_stat.SERVICE_COMPASS; // 4
 
-  std::vector<uint8_t> buffer( ros::serialization::serializationLength(nav_stat) );
+  std::vector<uint8_t> buffer(ros::serialization::serializationLength(nav_stat));
   ros::serialization::OStream stream(buffer.data(), buffer.size());
   ros::serialization::Serializer<sensor_msgs::NavSatStatus>::write(stream, nav_stat);
 
   FlatMessage flat_container;
   parser.deserializeIntoFlatMsg(Span<uint8_t>(buffer), &flat_container);
 
-  if(VERBOSE_TEST){ std::cout << " -------------------- " << std::endl;
+  if (VERBOSE_TEST)
+  {
+    std::cout << " -------------------- " << std::endl;
 
-    for(auto&it: flat_container.value) {
+    for (auto &it : flat_container.value)
+    {
       std::cout << it.first << " >> " << it.second.convert<double>() << std::endl;
     }
   }
 
-  EXPECT_EQ( flat_container.value[0].first.toStdString() , ("nav_stat/status"));
-  EXPECT_EQ( flat_container.value[0].second.convert<int>(), (int)nav_stat.STATUS_GBAS_FIX );
-  EXPECT_EQ( flat_container.value[1].first.toStdString() , ("nav_stat/service"));
-  EXPECT_EQ( flat_container.value[1].second.convert<int>(), (int)nav_stat.SERVICE_COMPASS );
+  EXPECT_EQ(flat_container.value[0].first.toStdString(), ("nav_stat/status"));
+  EXPECT_EQ(flat_container.value[0].second.convert<int>(), (int)nav_stat.STATUS_GBAS_FIX);
+  EXPECT_EQ(flat_container.value[1].first.toStdString(), ("nav_stat/service"));
+  EXPECT_EQ(flat_container.value[1].second.convert<int>(), (int)nav_stat.SERVICE_COMPASS);
 }
 
-TEST( Deserialize, DeserializeIMU)
-//int func()
+TEST(Deserialize, DeserializeIMU)
+// int func()
 {
   // We test this because to check if arrays with fixed length work.
   RosMsgParser::Parser parser("imu",
-        ROSType(DataType<sensor_msgs::Imu>::value()),
-        Definition<sensor_msgs::Imu>::value());
+                              ROSType(DataType<sensor_msgs::Imu>::value()),
+                              Definition<sensor_msgs::Imu>::value());
 
   sensor_msgs::Imu imu;
 
   imu.header.seq = 2016;
-  imu.header.stamp.sec  = 1234;
-  imu.header.stamp.nsec = 567*1000*1000;
+  imu.header.stamp.sec = 1234;
+  imu.header.stamp.nsec = 567 * 1000 * 1000;
   imu.header.frame_id = "pippo";
 
   imu.orientation.x = 11;
@@ -225,161 +410,161 @@ TEST( Deserialize, DeserializeIMU)
   imu.linear_acceleration.y = 32;
   imu.linear_acceleration.z = 33;
 
-  for (int i=0; i<9; i++)
+  for (int i = 0; i < 9; i++)
   {
-    imu.orientation_covariance[i]         = 40+i;
-    imu.angular_velocity_covariance[i]    = 50+i;
-    imu.linear_acceleration_covariance[i] = 60+i;
+    imu.orientation_covariance[i] = 40 + i;
+    imu.angular_velocity_covariance[i] = 50 + i;
+    imu.linear_acceleration_covariance[i] = 60 + i;
   }
 
-  std::vector<uint8_t> buffer( ros::serialization::serializationLength(imu) );
+  std::vector<uint8_t> buffer(ros::serialization::serializationLength(imu));
   ros::serialization::OStream stream(buffer.data(), buffer.size());
   ros::serialization::Serializer<sensor_msgs::Imu>::write(stream, imu);
 
   FlatMessage flat_container;
-  parser.deserializeIntoFlatMsg(Span<uint8_t>(buffer),  &flat_container);
+  parser.deserializeIntoFlatMsg(Span<uint8_t>(buffer), &flat_container);
 
-  if(VERBOSE_TEST){
+  if (VERBOSE_TEST)
+  {
 
     std::cout << " -------------------- " << std::endl;
-    for(auto&it: flat_container.value) {
+    for (auto &it : flat_container.value)
+    {
       std::cout << it.first << " >> " << it.second.convert<double>() << std::endl;
     }
   }
 
   int index = 0;
 
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/header/seq"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 2016 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/header/seq"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 2016);
   index++;
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/header/stamp"));
-  EXPECT_EQ( flat_container.value[index].second.convert<double>(),   double(1234.567)  );
-  EXPECT_EQ( flat_container.value[index].second.convert<ros::Time>(), imu.header.stamp  );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/header/stamp"));
+  EXPECT_EQ(flat_container.value[index].second.convert<double>(), double(1234.567));
+  EXPECT_EQ(flat_container.value[index].second.convert<ros::Time>(), imu.header.stamp);
   index++;
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/orientation/x"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 11 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/orientation/x"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 11);
   index++;
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/orientation/y"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 12 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/orientation/y"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 12);
   index++;
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/orientation/z"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 13 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/orientation/z"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 13);
   index++;
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/orientation/w"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 14 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/orientation/w"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 14);
   index++;
 
-  for(int i=0; i<9; i++)
+  for (int i = 0; i < 9; i++)
   {
     char str[64];
-    sprintf(str, "imu/orientation_covariance.%d",i);
-    EXPECT_EQ( flat_container.value[index].first.toStdString() , (str) );
-    EXPECT_EQ( flat_container.value[index].second.convert<int>(), 40+i );
+    sprintf(str, "imu/orientation_covariance.%d", i);
+    EXPECT_EQ(flat_container.value[index].first.toStdString(), (str));
+    EXPECT_EQ(flat_container.value[index].second.convert<int>(), 40 + i);
     index++;
   }
 
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/angular_velocity/x"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 21 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/angular_velocity/x"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 21);
   index++;
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/angular_velocity/y"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 22 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/angular_velocity/y"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 22);
   index++;
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/angular_velocity/z"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 23 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/angular_velocity/z"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 23);
   index++;
 
-  for(int i=0; i<9; i++)
+  for (int i = 0; i < 9; i++)
   {
     char str[64];
-    sprintf(str, "imu/angular_velocity_covariance.%d",i);
-    EXPECT_EQ( flat_container.value[index].first.toStdString() , (str) );
-    EXPECT_EQ( flat_container.value[index].second.convert<int>(), 50+i );
+    sprintf(str, "imu/angular_velocity_covariance.%d", i);
+    EXPECT_EQ(flat_container.value[index].first.toStdString(), (str));
+    EXPECT_EQ(flat_container.value[index].second.convert<int>(), 50 + i);
     index++;
   }
 
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/linear_acceleration/x"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 31 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/linear_acceleration/x"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 31);
   index++;
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/linear_acceleration/y"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 32 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/linear_acceleration/y"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 32);
   index++;
-  EXPECT_EQ( flat_container.value[index].first.toStdString() , ("imu/linear_acceleration/z"));
-  EXPECT_EQ( flat_container.value[index].second.convert<int>(), 33 );
+  EXPECT_EQ(flat_container.value[index].first.toStdString(), ("imu/linear_acceleration/z"));
+  EXPECT_EQ(flat_container.value[index].second.convert<int>(), 33);
   index++;
 
-  for(int i=0; i<9; i++)
+  for (int i = 0; i < 9; i++)
   {
     char str[64];
-    sprintf(str, "imu/linear_acceleration_covariance.%d",i);
-    EXPECT_EQ( flat_container.value[index].first.toStdString() , (str) );
-    EXPECT_EQ( flat_container.value[index].second.convert<int>(), 60+i );
+    sprintf(str, "imu/linear_acceleration_covariance.%d", i);
+    EXPECT_EQ(flat_container.value[index].first.toStdString(), (str));
+    EXPECT_EQ(flat_container.value[index].second.convert<int>(), 60 + i);
     index++;
   }
 
   //---------------------------------
-//  std::vector< std::pair<SString,std_msgs::Header>> headers;
-//  std::vector< std::pair<SString,geometry_msgs::Vector3>> vectors;
-//  std::vector< std::pair<SString,geometry_msgs::Quaternion>> quaternions;
+  //  std::vector< std::pair<SString,std_msgs::Header>> headers;
+  //  std::vector< std::pair<SString,geometry_msgs::Vector3>> vectors;
+  //  std::vector< std::pair<SString,geometry_msgs::Quaternion>> quaternions;
 
-//  ExtractSpecificROSMessages(type_map,  main_type,
-//                              "imu", buffer,
-//                              headers);
+  //  ExtractSpecificROSMessages(type_map,  main_type,
+  //                              "imu", buffer,
+  //                              headers);
 
-//  EXPECT_EQ(headers.size(), 1);
-//  const std_msgs::Header& header = headers[0].second;
-//  std::string header_prefix =  headers[0].first.toStdString();
-//  EXPECT_EQ( header_prefix, "imu/header");
-//  EXPECT_EQ(header.seq,        imu.header.seq);
-//  EXPECT_EQ(header.stamp.sec,  imu.header.stamp.sec);
-//  EXPECT_EQ(header.stamp.nsec, imu.header.stamp.nsec);
-//  EXPECT_EQ(header.frame_id,   imu.header.frame_id);
+  //  EXPECT_EQ(headers.size(), 1);
+  //  const std_msgs::Header& header = headers[0].second;
+  //  std::string header_prefix =  headers[0].first.toStdString();
+  //  EXPECT_EQ( header_prefix, "imu/header");
+  //  EXPECT_EQ(header.seq,        imu.header.seq);
+  //  EXPECT_EQ(header.stamp.sec,  imu.header.stamp.sec);
+  //  EXPECT_EQ(header.stamp.nsec, imu.header.stamp.nsec);
+  //  EXPECT_EQ(header.frame_id,   imu.header.frame_id);
 
-//  ExtractSpecificROSMessages(type_map,  main_type,
-//                              "imu", buffer,
-//                              quaternions);
+  //  ExtractSpecificROSMessages(type_map,  main_type,
+  //                              "imu", buffer,
+  //                              quaternions);
 
-//  EXPECT_EQ(quaternions.size(), 1);
-//  const geometry_msgs::Quaternion& quaternion = quaternions[0].second;
-//  std::string quaternion_prefix =  quaternions[0].first.toStdString();
-//  EXPECT_EQ( quaternion_prefix, "imu/orientation");
-//  EXPECT_EQ(quaternion.x,  imu.orientation.x);
-//  EXPECT_EQ(quaternion.y,  imu.orientation.y);
-//  EXPECT_EQ(quaternion.z,  imu.orientation.z);
-//  EXPECT_EQ(quaternion.w,  imu.orientation.w);
+  //  EXPECT_EQ(quaternions.size(), 1);
+  //  const geometry_msgs::Quaternion& quaternion = quaternions[0].second;
+  //  std::string quaternion_prefix =  quaternions[0].first.toStdString();
+  //  EXPECT_EQ( quaternion_prefix, "imu/orientation");
+  //  EXPECT_EQ(quaternion.x,  imu.orientation.x);
+  //  EXPECT_EQ(quaternion.y,  imu.orientation.y);
+  //  EXPECT_EQ(quaternion.z,  imu.orientation.z);
+  //  EXPECT_EQ(quaternion.w,  imu.orientation.w);
 
-//  ExtractSpecificROSMessages(type_map,  main_type,
-//                              "imu", buffer,
-//                              vectors);
+  //  ExtractSpecificROSMessages(type_map,  main_type,
+  //                              "imu", buffer,
+  //                              vectors);
 
-//  EXPECT_EQ(vectors.size(), 2);
-//  for( const auto& vect_pair: vectors)
-//  {
-//    if( vect_pair.first.toStdString() == "imu/angular_velocity")
-//    {
-//      EXPECT_EQ(vect_pair.second.x,  imu.angular_velocity.x);
-//      EXPECT_EQ(vect_pair.second.y,  imu.angular_velocity.y);
-//      EXPECT_EQ(vect_pair.second.z,  imu.angular_velocity.z);
-//    }
-//    else if( vect_pair.first.toStdString() == "imu/linear_acceleration")
-//    {
-//      EXPECT_EQ(vect_pair.second.x,  imu.linear_acceleration.x);
-//      EXPECT_EQ(vect_pair.second.y,  imu.linear_acceleration.y);
-//      EXPECT_EQ(vect_pair.second.z,  imu.linear_acceleration.z);
-//    }
-//    else{
-//      FAIL();
-//    }
-//  }
+  //  EXPECT_EQ(vectors.size(), 2);
+  //  for( const auto& vect_pair: vectors)
+  //  {
+  //    if( vect_pair.first.toStdString() == "imu/angular_velocity")
+  //    {
+  //      EXPECT_EQ(vect_pair.second.x,  imu.angular_velocity.x);
+  //      EXPECT_EQ(vect_pair.second.y,  imu.angular_velocity.y);
+  //      EXPECT_EQ(vect_pair.second.z,  imu.angular_velocity.z);
+  //    }
+  //    else if( vect_pair.first.toStdString() == "imu/linear_acceleration")
+  //    {
+  //      EXPECT_EQ(vect_pair.second.x,  imu.linear_acceleration.x);
+  //      EXPECT_EQ(vect_pair.second.y,  imu.linear_acceleration.y);
+  //      EXPECT_EQ(vect_pair.second.z,  imu.linear_acceleration.z);
+  //    }
+  //    else{
+  //      FAIL();
+  //    }
+  //  }
 }
 
-
-
-TEST( Deserialize, Int16MultiArrayDeserialize)
-//int func()
+TEST(Deserialize, Int16MultiArrayDeserialize)
+// int func()
 {
   RosMsgParser::Parser parser("multi_array",
-        ROSType(DataType<std_msgs::Int16MultiArray>::value()),
-        Definition<std_msgs::Int16MultiArray>::value());
+                              ROSType(DataType<std_msgs::Int16MultiArray>::value()),
+                              Definition<std_msgs::Int16MultiArray>::value());
 
   std_msgs::Int16MultiArray multi_array;
 
@@ -387,35 +572,37 @@ TEST( Deserialize, Int16MultiArrayDeserialize)
   multi_array.layout.data_offset = 42;
   multi_array.data.resize(N);
 
-  for (unsigned i=0; i<N; i++){
+  for (unsigned i = 0; i < N; i++)
+  {
     multi_array.data[i] = i;
   }
 
-  std::vector<uint8_t> buffer( ros::serialization::serializationLength(multi_array) );
+  std::vector<uint8_t> buffer(ros::serialization::serializationLength(multi_array));
   ros::serialization::OStream stream(buffer.data(), buffer.size());
   ros::serialization::Serializer<std_msgs::Int16MultiArray>::write(stream, multi_array);
 
   FlatMessage flat_container;
 
   EXPECT_NO_THROW(
-        parser.deserializeIntoFlatMsg(Span<uint8_t>(buffer),
-                                            &flat_container)
-        );
+      parser.deserializeIntoFlatMsg(Span<uint8_t>(buffer),
+                                    &flat_container));
 
-  if(VERBOSE_TEST){
+  if (VERBOSE_TEST)
+  {
     std::cout << " -------------------- " << std::endl;
 
-    for(auto&it: flat_container.value) {
+    for (auto &it : flat_container.value)
+    {
       std::cout << it.first << " >> " << it.second.convert<double>() << std::endl;
     }
   }
 }
 
-TEST( Deserialize, SensorImage)
+TEST(Deserialize, SensorImage)
 {
-  RosMsgParser::Parser parser( "image_raw",
-        ROSType(DataType<sensor_msgs::Image>::value()),
-        Definition<sensor_msgs::Image>::value());
+  RosMsgParser::Parser parser("image_raw",
+                              ROSType(DataType<sensor_msgs::Image>::value()),
+                              Definition<sensor_msgs::Image>::value());
 
   sensor_msgs::Image image;
   image.header.seq = 42;
@@ -423,42 +610,36 @@ TEST( Deserialize, SensorImage)
   image.header.frame_id = "hello";
   image.width = 640;
   image.height = 480;
-  image.step = 3*image.width;
-  image.data.resize( image.height * image.step, 1 );
+  image.step = 3 * image.width;
+  image.data.resize(image.height * image.step, 1);
   image.is_bigendian = 1;
 
-
-  std::vector<uint8_t> buffer( ros::serialization::serializationLength(image) );
+  std::vector<uint8_t> buffer(ros::serialization::serializationLength(image));
   ros::serialization::OStream stream(buffer.data(), buffer.size());
   ros::serialization::Serializer<sensor_msgs::Image>::write(stream, image);
 
   FlatMessage flat_container;
 
   EXPECT_NO_THROW(
-        parser.deserializeIntoFlatMsg(Span<uint8_t>(buffer),
-                                            &flat_container)
-        );
+      parser.deserializeIntoFlatMsg(Span<uint8_t>(buffer),
+                                    &flat_container));
 
   std::string json_txt;
   parser.deserializeIntoJson(buffer, &json_txt);
-
-  std::cout << json_txt << std::endl;
-
 }
-
 
 TEST(Deserialize, JointStateExtracSubfield)
 {
   RosMsgParser::Parser parser(
-        "PoseStamped",
-        ROSType(DataType<geometry_msgs::PoseStamped>::value()),
-        Definition<geometry_msgs::PoseStamped>::value());
+      "PoseStamped",
+      ROSType(DataType<geometry_msgs::PoseStamped>::value()),
+      Definition<geometry_msgs::PoseStamped>::value());
 
   geometry_msgs::PoseStamped pose;
 
   pose.header.seq = 2016;
-  pose.header.stamp.sec  = 1234;
-  pose.header.stamp.nsec = 567*1000*1000;
+  pose.header.stamp.sec = 1234;
+  pose.header.stamp.nsec = 567 * 1000 * 1000;
   pose.header.frame_id = "pippo";
 
   pose.pose.position.x = 1.0;
@@ -470,7 +651,7 @@ TEST(Deserialize, JointStateExtracSubfield)
   pose.pose.orientation.z = 6.0;
   pose.pose.orientation.w = 7.0;
 
-  std::vector<uint8_t> buffer( ros::serialization::serializationLength(pose) );
+  std::vector<uint8_t> buffer(ros::serialization::serializationLength(pose));
   ros::serialization::OStream stream(buffer.data(), buffer.size());
   ros::serialization::Serializer<geometry_msgs::PoseStamped>::write(stream, pose);
 
@@ -478,26 +659,27 @@ TEST(Deserialize, JointStateExtracSubfield)
   Span<uint8_t> buffer_view(buffer);
 
   auto header = parser.extractField<std_msgs::Header>(buffer_view);
-  auto point  = parser.extractField<geometry_msgs::Point>(buffer_view);
-  auto quat   = parser.extractField<geometry_msgs::Quaternion>(buffer_view);
+  auto point = parser.extractField<geometry_msgs::Point>(buffer_view);
+  auto quat = parser.extractField<geometry_msgs::Quaternion>(buffer_view);
 
-  EXPECT_EQ(header.seq,        pose.header.seq);
-  EXPECT_EQ(header.stamp.sec,  pose.header.stamp.sec);
+  EXPECT_EQ(header.seq, pose.header.seq);
+  EXPECT_EQ(header.stamp.sec, pose.header.stamp.sec);
   EXPECT_EQ(header.stamp.nsec, pose.header.stamp.nsec);
-  EXPECT_EQ(header.frame_id,   pose.header.frame_id);
+  EXPECT_EQ(header.frame_id, pose.header.frame_id);
 
-  EXPECT_EQ(point.x,  pose.pose.position.x);
-  EXPECT_EQ(point.y,  pose.pose.position.y);
-  EXPECT_EQ(point.z,  pose.pose.position.z);
+  EXPECT_EQ(point.x, pose.pose.position.x);
+  EXPECT_EQ(point.y, pose.pose.position.y);
+  EXPECT_EQ(point.z, pose.pose.position.z);
 
-  EXPECT_EQ(quat.x,  pose.pose.orientation.x);
-  EXPECT_EQ(quat.y,  pose.pose.orientation.y);
-  EXPECT_EQ(quat.z,  pose.pose.orientation.z);
-  EXPECT_EQ(quat.w,  pose.pose.orientation.w);
+  EXPECT_EQ(quat.x, pose.pose.orientation.x);
+  EXPECT_EQ(quat.y, pose.pose.orientation.y);
+  EXPECT_EQ(quat.z, pose.pose.orientation.z);
+  EXPECT_EQ(quat.w, pose.pose.orientation.w);
 }
 
 // Run all the tests that were declared with TEST()
-int main(int argc, char **argv){
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Enhancing the capabilities of ros_msg_parser by adding support for converting JSON strings into ROS messages without knowing the message type in compilation time. IMO, this functionality fills a crucial gap in the ROS ecosystem, particularly for scenarios where dynamic integration with external systems like MQTT brokers is required.

The motivation behind this update is to provide a dynamic integration mechanism similar to what is offered by the Python-based ros_bridge package, but for C++ which lacks reflection capabilities.

The core reason is to bridge ROS C++ with MQTT brokers using json payloads, dynamically casting json objects into ROS messages.

I edited [mqtt_client](https://github.com/ika-rwth-aachen/mqtt_client) and did pull request [51](https://github.com/ika-rwth-aachen/mqtt_client/pull/51) , which depends on the updates of this package.

The [mqtt_client](https://github.com/ika-rwth-aachen/mqtt_client) already have a couple of open issues regarding this functionality.

Key Contributions:
-Implemented the functionality and added the required tests to ensure the correctness.
-Demonstrated the correct integration of the new function into the existing package by adding a test of the complete cycle of serialization, deserializeIntoJson, and serializeFromJson into a ROS message.
-Most importantly, I tried my best to integrate it seamlessly into the codebase following the same coding style, so that the edits don't look like a sore thumb!, and also insuring backward compatibility.



I believe this update benefits ROS interoperability, and is important to the community, 
